### PR TITLE
Millisecond timestamps attached to messages

### DIFF
--- a/embedded/SUFST/Inc/message_types.h
+++ b/embedded/SUFST/Inc/message_types.h
@@ -13,15 +13,15 @@
  * @brief Torque request message
  */
 typedef struct {
-
+	UINT timestamp;
 	UINT value;
-
 } torque_request_message_t;
 
 /**
  * @brief Control input message
  */
 typedef struct {
+	UINT timestamp;
 	UINT input;
 } control_input_message_t;
 

--- a/embedded/SUFST/Inc/messaging_system.h
+++ b/embedded/SUFST/Inc/messaging_system.h
@@ -18,7 +18,7 @@
 #define TORQUE_REQUEST_QUEUE_SIZE			100
 #define TORQUE_REQUEST_QUEUE_NAME			"Torque Request Queue"
 
-#define CONTROL_INPUT_QUEUE_MESSAGE_SIZE	1
+#define CONTROL_INPUT_QUEUE_MESSAGE_SIZE	2
 #define CONTROL_INPUT_QUEUE_SIZE			100
 #define CONTROL_INPUT_QUEUE_NAME			"Control Input Queue"
 
@@ -34,5 +34,6 @@ extern TX_QUEUE control_input_queue;
 UINT message_system_init();
 UINT message_post(VOID* message_ptr, TX_QUEUE* queue_ptr);
 UINT message_receive(VOID* dest_ptr, TX_QUEUE* queue_ptr);
+void message_set_timestamp(UINT* timestamp_ptr);
 
 #endif

--- a/embedded/SUFST/Src/control_thread.c
+++ b/embedded/SUFST/Src/control_thread.c
@@ -43,9 +43,10 @@ void control_thread_entry(ULONG thread_input)
 		// 		(using placeholder function at the moment)
 		UINT torque_request = pid_control(input_message.input);
 
-		// send the torque request to the can thread
+		// create and send the torque request to the can thread
 		torque_request_message_t torque_message;
 		torque_message.value = torque_request;
+		torque_message.timestamp = input_message.timestamp;
 
 		message_post((VOID*) &torque_message, &torque_request_queue);
 

--- a/embedded/SUFST/Src/messaging_system.c
+++ b/embedded/SUFST/Src/messaging_system.c
@@ -8,6 +8,8 @@
 #include "messaging_system.h"
 #include <stdint.h>
 
+#define TIMESTAMP_TO_MS		(1000 / TX_TIMER_TICKS_PER_SECOND)
+
 /**
  * @brief Queue for sensor messages
  */
@@ -65,6 +67,24 @@ UINT message_receive(VOID* dest_ptr, TX_QUEUE* queue_ptr)
 {
 	return tx_queue_receive(queue_ptr, dest_ptr, TX_WAIT_FOREVER);
 }
+
+/**
+ * @brief 		Sets the timestamp of the message
+ *
+ * @details		At the moment this uses the time since processor startup in milliseconds as
+ * 				the timestamp. In future this might need to be synchronised with other parts
+ * 				of the larger system.
+ *
+ * @note		The timestamp will overflow after around 49.7 days.
+ *
+ * @param[in]	timestamp_ptr	UINT pointer to message struct field to store timestamp in
+ */
+void message_set_timestamp(UINT* timestamp_ptr)
+{
+	ULONG current_time = tx_time_get() * TIMESTAMP_TO_MS;
+	*timestamp_ptr = (UINT) current_time;	// this cast is safe on this ThreadX port as sizeof(UINT) is the same as sizeof(ULONG)
+}
+
 
 
 

--- a/embedded/SUFST/Src/sensor_thread.c
+++ b/embedded/SUFST/Src/sensor_thread.c
@@ -50,12 +50,15 @@ void sensor_thread_entry(ULONG thread_input)
 
 		if (read_adc_blocking(&message.input) == ADC_OK)
 		{
+			// timestamp the message
+			message_set_timestamp(&message.timestamp);
+
 			// send message to the control thread
 			message_post((VOID*) &message, &control_input_queue);
 		}
 
 		// sleep thread to allow other threads to run
-		tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND);
+		tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND / 10);
 	}
 
 }


### PR DESCRIPTION
- Using `tx_time_get()` from ThreadX API to get the time since entering the kernel in milliseconds as a timestamp.
- This is only accurate to 10ms because ThreadX ticks 100 times per second. If necessary, it is possible to get greater precision and date/time functionality by instead using the RTC.
- Timestamp stored in `UINT` type (32-bit unsigned) which will only overflow after 49.7 days.
- Should also be useful later for timestamping telemetry messages.