### PR TITLE
Inverter broadcast configuration

### DIFF
--- a/embedded/Core/Src/app_threadx.c
+++ b/embedded/Core/Src/app_threadx.c
@@ -170,7 +170,12 @@ UINT App_ThreadX_Init(VOID *memory_ptr)
     // CAN
     if (ret == TX_SUCCESS)
     {
-        //pm100_init();
+        pm100_status_t status = pm100_init();
+        
+        if (status != PM100_OK)
+        {
+            ret = TX_START_ERROR;
+        }
     }
 
     /*************************
@@ -180,6 +185,10 @@ UINT App_ThreadX_Init(VOID *memory_ptr)
     if (ret == TX_SUCCESS)
     {
         wait_for_ready_to_drive();
+    }
+    else 
+    {
+        tx_thread_resume(&fault_state_thread);
     }
 
     /* USER CODE END App_ThreadX_Init */

--- a/embedded/SUFST/Inc/CAN/can_driver.h
+++ b/embedded/SUFST/Inc/CAN/can_driver.h
@@ -12,17 +12,9 @@
 #include <stdint.h>
 #include "fdcan.h"
 
-/* 
- * definitions
- */
 #define STD				FDCAN_STANDARD_ID
 #define EXT				FDCAN_EXTENDED_ID
 #define CAN_ID_OFFSET 	0xA0
-
-/* Type Definitions ------------------------------------------------------------------------*/
-
-/* enum for inputs vector index */
-/* each broadcast usually has two bytes */
 
 /** 
  * @brief 	CAN input enums

--- a/embedded/SUFST/Inc/config.h
+++ b/embedded/SUFST/Inc/config.h
@@ -69,7 +69,7 @@
 #define INVERTER_BROADCAST_FAULT_CODES          0
 #define INVERTER_BROADCAST_TORQUE_TIMER         0
 #define INVERTER_BROADCAST_MODULATION_FLUX      0
-#define INVERTER_BROADCAST_FIRMWARE_INFORMATION 0
+#define INVERTER_BROADCAST_FIRMWARE_INFO        0
 #define INVERTER_BROADCAST_DIAGNOSTIC_DATA      0
 
 /***************************************************************************

--- a/embedded/SUFST/Inc/config.h
+++ b/embedded/SUFST/Inc/config.h
@@ -20,60 +20,78 @@
  ***************************************************************************/
 
 #ifndef COMPETITION_MODE
-    #define COMPETITION_MODE		0
+    #define COMPETITION_MODE		        0
 #endif
 
 /***************************************************************************
  * ready-to-drive
  ***************************************************************************/
 
-#define READY_TO_DRIVE_OVERRIDE		1		// set to 0 to use the 'USER' button as the ready-to-drive signal
-#define READY_TO_DRIVE_BUZZER_TIME	2500	// in ms
+#define READY_TO_DRIVE_OVERRIDE		        1		// set to 0 to use the 'USER' button as the ready-to-drive signal
+#define READY_TO_DRIVE_BUZZER_TIME	        2500	// in ms
 
 /***************************************************************************
  * fault state
  ***************************************************************************/
 
-#define FAULT_STATE_LED_BLINK_RATE 	2		// in Hz
+#define FAULT_STATE_LED_BLINK_RATE 	        2		// in Hz
 
 /***************************************************************************
  * thread priorities
  ***************************************************************************/
 
-#define FAULT_STATE_THREAD_PRIORITY	0		// maximum priority
-#define SENSOR_THREAD_PRIORITY		3
-#define CONTROL_THREAD_PRIORITY		3
-#define CAN_THREAD_PRIORITY			2
+#define FAULT_STATE_THREAD_PRIORITY	        0		// maximum priority
+#define SENSOR_THREAD_PRIORITY		        3
+#define CONTROL_THREAD_PRIORITY		        3
+#define CAN_THREAD_PRIORITY			        2
 
 /***************************************************************************
  * CAN / inverter
+
  ***************************************************************************/
 
-#define INVERTER_SPEED_MODE             0       // replace torque requests with speed requests
-#define INVERTER_TORQUE_REQUEST_TIMEOUT	100		// in ms
-#define INVERTER_EEPROM_MAX_RETRY		10		// maximum number of retry attempts
-#define INVERTER_EEPROM_RETRY_DELAY		100		// in ms
+#define INVERTER_SPEED_MODE                 0       // replace torque requests with speed requests
+#define INVERTER_TORQUE_REQUEST_TIMEOUT	    100		// in ms
+#define INVERTER_EEPROM_MAX_RETRY		    10		// maximum number of retry attempts
+#define INVERTER_EEPROM_RETRY_DELAY		    100		// in ms
+
+#define INVERTER_BROADCAST_TEMPERATURE_1        0
+#define INVERTER_BROADCAST_TEMPERATURE_2        0
+#define INVERTER_BROADCAST_TEMPERATURE_3        0
+#define INVERTER_BROADCAST_ANALOG_INPUTS        0
+#define INVERTER_BROADCAST_DIGITAL_INPUTS       0
+#define INVERTER_BROADCAST_MOTOR_POSITION       0
+#define INVERTER_BROADCAST_CURRENTS             0
+#define INVERTER_BROADCAST_VOLTAGES             0
+#define INVERTER_BROADCAST_FLUX                 0
+#define INVERTER_BROADCAST_INTERNAL_VOLTAGES    0
+#define INVERTER_BROADCAST_INTERNAL_STATES      0
+#define INVERTER_BROADCAST_FAULT_CODES          0
+#define INVERTER_BROADCAST_TORQUE_TIMER         0
+#define INVERTER_BROADCAST_MODULATION_FLUX      0
+#define INVERTER_BROADCAST_FIRMWARE_INFORMATION 0
+#define INVERTER_BROADCAST_DIAGNOSTIC_DATA      0
 
 /***************************************************************************
  * sensors
  ***************************************************************************/
 
-#define THROTTLE_INPUT_RESOLUTION	16		// resolution of ADC
-#define THROTTLE_SCALED_RESOLUTION	10		// scaled resolution sent to control thread
-#define THROTTLE_DEADZONE_FRACTION	0.01	// fractional dead-zone below which throttle always zero
-#define THROTTLE_MAX_DIFF_FRACTION	0.05	// fractional maximum allowed difference between ADC readings
-#define THROTTLE_ENABLE_DIFF_CHECK	1		// set to 1 to enable check for discrepancy between ADC readings
-#define THROTTLE_ENABLE_DEADZONE	0		// set to 1 to enable dead-zone
+#define THROTTLE_INPUT_RESOLUTION	        16		// resolution of ADC
+#define THROTTLE_SCALED_RESOLUTION	        10		// scaled resolution sent to control thread
+#define THROTTLE_DEADZONE_FRACTION	        0.01	// fractional dead-zone below which throttle always zero
+#define THROTTLE_MAX_DIFF_FRACTION	        0.05	// fractional maximum allowed difference between ADC readings
+#define THROTTLE_ENABLE_DIFF_CHECK	        1		// set to 1 to enable check for discrepancy between ADC readings
+#define THROTTLE_ENABLE_DEADZONE	        0		// set to 1 to enable dead-zone
 
 /***************************************************************************
  * testbenches
  ***************************************************************************/
 
 // enable flags
-#define RUN_THROTTLE_TESTBENCH		1		// throttle input from lookup table
-#define RUN_FAULT_STATE_TESTBENCH	1		// 'USER' button (after ready to drive) causes fault state
+#define RUN_THROTTLE_TESTBENCH		        1		// throttle input from lookup table
+#define RUN_FAULT_STATE_TESTBENCH	        1		// 'USER' button (after ready to drive) causes fault state
 
 // testbench parameters
-#define THROTTLE_TESTBENCH_LAPS 	4		// 1 for standing start only, 2+ to add flying laps
+#define THROTTLE_TESTBENCH_LAPS 	        4		// 1 for standing start only, 2+ to add flying laps
 
 #endif

--- a/embedded/SUFST/Src/CAN/pm100.c
+++ b/embedded/SUFST/Src/CAN/pm100.c
@@ -24,23 +24,23 @@
 /*
  * broadcast configuration bytes
  */
-#define BROADCAST_BYTE_4	(0xFF ^ (INVERTER_BROADCAST_TEMPERATURE_1     << 0) \
-								  ^ (INVERTER_BROADCAST_TEMPERATURE_2     << 1) \
-								  ^ (INVERTER_BROADCAST_TEMPERATURE_3     << 2) \
-								  ^ (INVERTER_BROADCAST_ANALOG_INPUTS     << 3) \
-								  ^ (INVERTER_BROADCAST_DIGITAL_INPUTS    << 4) \
-								  ^ (INVERTER_BROADCAST_MOTOR_POSITION    << 5) \
-								  ^ (INVERTER_BROADCAST_CURRENTS          << 6) \
-								  ^ (INVERTER_BROADCAST_VOLTAGES          << 8) )
+#define BROADCAST_BYTE_4	(  (INVERTER_BROADCAST_TEMPERATURE_1     << 0) \
+                             | (INVERTER_BROADCAST_TEMPERATURE_2     << 1) \
+                             | (INVERTER_BROADCAST_TEMPERATURE_3     << 2) \
+                             | (INVERTER_BROADCAST_ANALOG_INPUTS     << 3) \
+                             | (INVERTER_BROADCAST_DIGITAL_INPUTS    << 4) \
+                             | (INVERTER_BROADCAST_MOTOR_POSITION    << 5) \
+                             | (INVERTER_BROADCAST_CURRENTS          << 6) \
+                             | (INVERTER_BROADCAST_VOLTAGES          << 8) )
 
-#define BROADCAST_BYTE_5	(0xFF ^ (INVERTER_BROADCAST_FLUX           	  << 0) \
-								  ^	(INVERTER_BROADCAST_INTERNAL_VOLTAGES << 1) \
-								  ^ (INVERTER_BROADCAST_INTERNAL_STATES   << 2) \
-								  ^ (INVERTER_BROADCAST_FAULT_CODES       << 3) \
-								  ^ (INVERTER_BROADCAST_TORQUE_TIMER	  << 4) \
-								  ^ (INVERTER_BROADCAST_MODULATION_FLUX   << 5) \
-								  ^ (INVERTER_BROADCAST_FIRMWARE_INFO     << 6) \
-								  ^ (INVERTER_BROADCAST_DIAGNOSTIC_DATA   << 7) )
+#define BROADCAST_BYTE_5	(  (INVERTER_BROADCAST_FLUX           	 << 0) \
+                             | (INVERTER_BROADCAST_INTERNAL_VOLTAGES << 1) \
+                             | (INVERTER_BROADCAST_INTERNAL_STATES   << 2) \
+                             | (INVERTER_BROADCAST_FAULT_CODES       << 3) \
+                             | (INVERTER_BROADCAST_TORQUE_TIMER	  	 << 4) \
+                             | (INVERTER_BROADCAST_MODULATION_FLUX   << 5) \
+                             | (INVERTER_BROADCAST_FIRMWARE_INFO     << 6) \
+                             | (INVERTER_BROADCAST_DIAGNOSTIC_DATA   << 7) )
 
 #define BROADCAST_BYTE_6	(0xFF)
 
@@ -53,15 +53,15 @@ static queue_msg_t pm100_command_msg =
 {
     .Tx_header =
     {
-    		CAN_ID_OFFSET + 0x020,
-			FDCAN_STANDARD_ID,
-			FDCAN_DATA_FRAME,
-			FDCAN_DLC_BYTES_8,
-			FDCAN_ESI_ACTIVE,
-			FDCAN_BRS_OFF,
-			FDCAN_CLASSIC_CAN,
-			FDCAN_NO_TX_EVENTS,
-			0
+            CAN_ID_OFFSET + 0x020,
+            FDCAN_STANDARD_ID,
+            FDCAN_DATA_FRAME,
+            FDCAN_DLC_BYTES_8,
+            FDCAN_ESI_ACTIVE,
+            FDCAN_BRS_OFF,
+            FDCAN_CLASSIC_CAN,
+            FDCAN_NO_TX_EVENTS,
+            0
     },
     .data = {0, 0, 0, 0, 0, 0, 0, 0}
 };
@@ -73,15 +73,15 @@ static queue_msg_t pm100_parameter_write_msg =
 {
     .Tx_header =
     {
-    		CAN_ID_OFFSET + 0x021,
-			FDCAN_STANDARD_ID,
-			FDCAN_DATA_FRAME,
-			FDCAN_DLC_BYTES_8,
-			FDCAN_ESI_ACTIVE,
-			FDCAN_BRS_OFF,
-			FDCAN_CLASSIC_CAN,
-			FDCAN_NO_TX_EVENTS,
-			0
+            CAN_ID_OFFSET + 0x021,
+            FDCAN_STANDARD_ID,
+            FDCAN_DATA_FRAME,
+            FDCAN_DLC_BYTES_8,
+            FDCAN_ESI_ACTIVE,
+            FDCAN_BRS_OFF,
+            FDCAN_CLASSIC_CAN,
+            FDCAN_NO_TX_EVENTS,
+            0
     },
     .data = {0, 0, 1, 0, 0, 0, 0, 0} // byte 3 set to 1 for write
 };
@@ -93,15 +93,15 @@ static queue_msg_t pm100_parameter_read_msg =
 {
     .Tx_header =
     {
-    		CAN_ID_OFFSET + 0x021,
-			FDCAN_STANDARD_ID,
-			FDCAN_DATA_FRAME,
-			FDCAN_DLC_BYTES_8,
-			FDCAN_ESI_ACTIVE,
-			FDCAN_BRS_OFF,
-			FDCAN_CLASSIC_CAN,
-			FDCAN_NO_TX_EVENTS,
-			0
+            CAN_ID_OFFSET + 0x021,
+            FDCAN_STANDARD_ID,
+            FDCAN_DATA_FRAME,
+            FDCAN_DLC_BYTES_8,
+            FDCAN_ESI_ACTIVE,
+            FDCAN_BRS_OFF,
+            FDCAN_CLASSIC_CAN,
+            FDCAN_NO_TX_EVENTS,
+            0
     },
     .data = {0, 0, 0, 0, 0, 0, 0, 0}
 };
@@ -111,8 +111,8 @@ static queue_msg_t pm100_parameter_read_msg =
  */
 pm100_status_t pm100_init()
 {
-	// TODO(@hashyaha) initialisation values (e.g. activate/deactivate specific broadcast messages)
-	return pm100_eeprom_write_blocking(PM100_TIMEOUT_ADDR, PM100_TIMEOUT_VALUE);
+    // TODO(@hashyaha) initialisation values (e.g. activate/deactivate specific broadcast messages)
+    return pm100_eeprom_write_blocking(PM100_TIMEOUT_ADDR, PM100_TIMEOUT_VALUE);
 }
 
 /**
@@ -126,36 +126,36 @@ pm100_status_t pm100_init()
  */
 pm100_status_t pm100_eeprom_write_blocking(uint16_t parameter_address, uint16_t data)
 {
-	// construct message
-	pm100_parameter_write_msg.data[0] = (parameter_address & 0x00FF);
-	pm100_parameter_write_msg.data[1] = ((parameter_address & 0xFF00) >> 8);
-	pm100_parameter_write_msg.data[5] = ((data & 0xFF00) >> 8);
-	pm100_parameter_write_msg.data[4] = (data & 0x00FF);
+    // construct message
+    pm100_parameter_write_msg.data[0] = (parameter_address & 0x00FF);
+    pm100_parameter_write_msg.data[1] = ((parameter_address & 0xFF00) >> 8);
+    pm100_parameter_write_msg.data[5] = ((data & 0xFF00) >> 8);
+    pm100_parameter_write_msg.data[4] = (data & 0x00FF);
 
-	// loop until parameter set successfully or max retry attempts reached
-	uint32_t suc = 0;
-	uint16_t res_ad = 0;
-	UINT attempts = 0;
+    // loop until parameter set successfully or max retry attempts reached
+    uint32_t suc = 0;
+    uint16_t res_ad = 0;
+    UINT attempts = 0;
 
-	while ((res_ad != parameter_address || !suc)
-	  && (attempts < INVERTER_EEPROM_MAX_RETRY))
-	{
-		// transmit message
-		CAN_Send(pm100_parameter_write_msg);
-		attempts++;
+    while ((res_ad != parameter_address || !suc)
+      && (attempts < INVERTER_EEPROM_MAX_RETRY))
+    {
+        // transmit message
+        CAN_Send(pm100_parameter_write_msg);
+        attempts++;
 
-		// allow time for a response
-		// -> have to use RTC for delay because EEPROM write happens on system initialisation
-		//    before the scheduler starts
-		// -> can't use HAL_Delay() because SysTick doesn't tick with RTOS
-		rtc_delay(INVERTER_EEPROM_RETRY_DELAY);
+        // allow time for a response
+        // -> have to use RTC for delay because EEPROM write happens on system initialisation
+        //    before the scheduler starts
+        // -> can't use HAL_Delay() because SysTick doesn't tick with RTOS
+        rtc_delay(INVERTER_EEPROM_RETRY_DELAY);
 
-		// check for success
-		suc = CAN_inputs[PARAMETER_RESPONSE_WRITE_SUCCESS];
-		res_ad = CAN_inputs[PARAMETER_RESPONSE_ADDRESS];
-	}
+        // check for success
+        suc = CAN_inputs[PARAMETER_RESPONSE_WRITE_SUCCESS];
+        res_ad = CAN_inputs[PARAMETER_RESPONSE_ADDRESS];
+    }
 
-	return PM100_OK;
+    return PM100_OK;
 }
 
 /**
@@ -167,29 +167,29 @@ pm100_status_t pm100_eeprom_write_blocking(uint16_t parameter_address, uint16_t 
  */
 pm100_status_t pm100_eeprom_read_blocking(uint16_t parameter_address)
 {
-	// construct message
-	pm100_parameter_read_msg.data[0] = (parameter_address & 0x00FF);
-	pm100_parameter_read_msg.data[1] = ((parameter_address & 0xFF00) >> 8);
+    // construct message
+    pm100_parameter_read_msg.data[0] = (parameter_address & 0x00FF);
+    pm100_parameter_read_msg.data[1] = ((parameter_address & 0xFF00) >> 8);
 
-	// loop until parameter read successfully or max retry attempts reached
-	uint32_t res_data = 0;
-	uint16_t res_ad = 0;
-	UINT attempts = 0;
+    // loop until parameter read successfully or max retry attempts reached
+    uint32_t res_data = 0;
+    uint16_t res_ad = 0;
+    UINT attempts = 0;
 
     while (res_ad != parameter_address
-    		&& attempts < INVERTER_EEPROM_MAX_RETRY)
+            && attempts < INVERTER_EEPROM_MAX_RETRY)
     {
-    	// transmit message
-    	CAN_Send(pm100_parameter_read_msg);
-    	attempts++;
+        // transmit message
+        CAN_Send(pm100_parameter_read_msg);
+        attempts++;
 
-		// allow time for a response
-		// -> have to use RTC for delay because EEPROM write happens on system initialisation
-		//    before the scheduler starts
-		// -> can't use HAL_Delay() because SysTick doesn't tick with RTOS
-    	rtc_delay(INVERTER_EEPROM_RETRY_DELAY);
+        // allow time for a response
+        // -> have to use RTC for delay because EEPROM write happens on system initialisation
+        //    before the scheduler starts
+        // -> can't use HAL_Delay() because SysTick doesn't tick with RTOS
+        rtc_delay(INVERTER_EEPROM_RETRY_DELAY);
 
-    	// check for success
+        // check for success
         res_data = CAN_inputs[PARAMETER_RESPONSE_DATA];
         res_ad = CAN_inputs[PARAMETER_RESPONSE_ADDRESS];
     }
@@ -206,24 +206,24 @@ pm100_status_t pm100_eeprom_read_blocking(uint16_t parameter_address)
 pm100_status_t pm100_command_tx(pm100_command_t* command_data)
 {
   // construct message
-	pm100_command_msg.data[0] = (command_data->torque_command & 0x00FF);
-	pm100_command_msg.data[1] = ((command_data->torque_command & 0xFF00) >> 8);
-	pm100_command_msg.data[2] = (command_data->speed_command & 0x00FF);
-	pm100_command_msg.data[3] = ((command_data->speed_command & 0xFF00) >> 8);
-	pm100_command_msg.data[4] = command_data->direction;
-	pm100_command_msg.data[5] = command_data->inverter_enable;
-	pm100_command_msg.data[5] |= command_data->inverter_discharge << 1;
-	pm100_command_msg.data[5] |= command_data->speed_mode_enable << 2;
-	pm100_command_msg.data[6] = (command_data->commanded_torque_limit & 0x00FF);
-	pm100_command_msg.data[7] = ((command_data->commanded_torque_limit & 0xFF00) >> 8);
+    pm100_command_msg.data[0] = (command_data->torque_command & 0x00FF);
+    pm100_command_msg.data[1] = ((command_data->torque_command & 0xFF00) >> 8);
+    pm100_command_msg.data[2] = (command_data->speed_command & 0x00FF);
+    pm100_command_msg.data[3] = ((command_data->speed_command & 0xFF00) >> 8);
+    pm100_command_msg.data[4] = command_data->direction;
+    pm100_command_msg.data[5] = command_data->inverter_enable;
+    pm100_command_msg.data[5] |= command_data->inverter_discharge << 1;
+    pm100_command_msg.data[5] |= command_data->speed_mode_enable << 2;
+    pm100_command_msg.data[6] = (command_data->commanded_torque_limit & 0x00FF);
+    pm100_command_msg.data[7] = ((command_data->commanded_torque_limit & 0xFF00) >> 8);
 
   // send message
-	if (CAN_Send(pm100_command_msg) != HAL_OK)
-	{
-		return PM100_ERROR;
-	}
+    if (CAN_Send(pm100_command_msg) != HAL_OK)
+    {
+        return PM100_ERROR;
+    }
   
-	return PM100_OK;
+    return PM100_OK;
 }
 
 /**
@@ -235,24 +235,24 @@ pm100_status_t pm100_command_tx(pm100_command_t* command_data)
  */
 pm100_status_t pm100_torque_command_tx(UINT torque)
 {
-	// initialise command data to 0
-	pm100_command_t pm100_cmd = {0};
-	pm100_status_t status;
+    // initialise command data to 0
+    pm100_command_t pm100_cmd = {0};
+    pm100_status_t status;
 
   // handle lockout
-	if(CAN_inputs[INVERTER_ENABLE_LOCKOUT] == 1)
-	{
-		status = pm100_command_tx(&pm100_cmd);
-	}
-	// transmit torque request
-	else
-	{
-		pm100_cmd.direction = DIRECTION_COMMAND;
-		pm100_cmd.torque_command = (uint16_t) torque;
-		pm100_cmd.inverter_enable = 1;
-		status = pm100_command_tx(&pm100_cmd);
-	}
-	return status;
+    if(CAN_inputs[INVERTER_ENABLE_LOCKOUT] == 1)
+    {
+        status = pm100_command_tx(&pm100_cmd);
+    }
+    // transmit torque request
+    else
+    {
+        pm100_cmd.direction = DIRECTION_COMMAND;
+        pm100_cmd.torque_command = (uint16_t) torque;
+        pm100_cmd.inverter_enable = 1;
+        status = pm100_command_tx(&pm100_cmd);
+    }
+    return status;
 }
 
 #if INVERTER_SPEED_MODE
@@ -265,25 +265,25 @@ pm100_status_t pm100_torque_command_tx(UINT torque)
  */
 pm100_status_t pm100_speed_command_tx(UINT speed)
 {
-	// initialise command data to 0
-	pm100_command_t pm100_cmd = {0};
-	pm100_status_t status;
+    // initialise command data to 0
+    pm100_command_t pm100_cmd = {0};
+    pm100_status_t status;
 
-  	// handle lockout
-	if(CAN_inputs[INVERTER_ENABLE_LOCKOUT] == 1)
-	{
-		pm100_cmd.speed_mode_enable = 1;
-		status = pm100_command_tx(&pm100_cmd);
-	}
-	// transmit speed request
-	else
-	{
-		pm100_cmd.direction = DIRECTION_COMMAND;
-		pm100_cmd.speed_command = (uint16_t) speed;
-		pm100_cmd.inverter_enable = 1;
-		pm100_cmd.speed_mode_enable = 1;
-		status = pm100_command_tx(&pm100_cmd);
-	}
-	return status;
+      // handle lockout
+    if(CAN_inputs[INVERTER_ENABLE_LOCKOUT] == 1)
+    {
+        pm100_cmd.speed_mode_enable = 1;
+        status = pm100_command_tx(&pm100_cmd);
+    }
+    // transmit speed request
+    else
+    {
+        pm100_cmd.direction = DIRECTION_COMMAND;
+        pm100_cmd.speed_command = (uint16_t) speed;
+        pm100_cmd.inverter_enable = 1;
+        pm100_cmd.speed_mode_enable = 1;
+        status = pm100_command_tx(&pm100_cmd);
+    }
+    return status;
 }
 #endif

--- a/embedded/SUFST/Src/CAN/pm100.c
+++ b/embedded/SUFST/Src/CAN/pm100.c
@@ -21,6 +21,30 @@
 #define PM100_TIMEOUT_VALUE			(INVERTER_TORQUE_REQUEST_TIMEOUT / 3)	// divide ms timeout in config by three
 #define PM100_DIRECTION_COMMAND		1										// 0: reverse, 1: forward
 
+/*
+ * broadcast configuration bytes
+ */
+#define BROADCAST_BYTE_4	(0xFF ^ (INVERTER_BROADCAST_TEMPERATURE_1     << 0) \
+								  ^ (INVERTER_BROADCAST_TEMPERATURE_2     << 1) \
+								  ^ (INVERTER_BROADCAST_TEMPERATURE_3     << 2) \
+								  ^ (INVERTER_BROADCAST_ANALOG_INPUTS     << 3) \
+								  ^ (INVERTER_BROADCAST_DIGITAL_INPUTS    << 4) \
+								  ^ (INVERTER_BROADCAST_MOTOR_POSITION    << 5) \
+								  ^ (INVERTER_BROADCAST_CURRENTS          << 6) \
+								  ^ (INVERTER_BROADCAST_VOLTAGES          << 8) )
+
+#define BROADCAST_BYTE_5	(0xFF ^ (INVERTER_BROADCAST_FLUX           	  << 0) \
+								  ^	(INVERTER_BROADCAST_INTERNAL_VOLTAGES << 1) \
+								  ^ (INVERTER_BROADCAST_INTERNAL_STATES   << 2) \
+								  ^ (INVERTER_BROADCAST_FAULT_CODES       << 3) \
+								  ^ (INVERTER_BROADCAST_TORQUE_TIMER	  << 4) \
+								  ^ (INVERTER_BROADCAST_MODULATION_FLUX   << 5) \
+								  ^ (INVERTER_BROADCAST_FIRMWARE_INFO     << 6) \
+								  ^ (INVERTER_BROADCAST_DIAGNOSTIC_DATA   << 7) )
+
+#define BROADCAST_BYTE_6	(0xFF)
+
+#define BROADCAST_BYTE_7	(0xFF)
 
 /**
  * @brief PM100 command message


### PR DESCRIPTION
- Configuration header settings to enable desired types of inverter broadcast messages.
- Construction of lo word for broadcast configuration parameter command message.
- Transmission of broadcast configuration command on initialisation.

Closes #94 