### PR TITLE
Restructure initialisation

### DIFF
--- a/embedded/.vscode/settings.json
+++ b/embedded/.vscode/settings.json
@@ -26,7 +26,9 @@
         "can_parser.h": "c",
         "can_device_state.h": "c",
         "pm100.h": "c",
-        "adc.h": "c"
+        "adc.h": "c",
+        "can_tx_thread.h": "c",
+        "init.h": "c"
     },
     "cortex-debug.variableUseNaturalFormat": true,
 }

--- a/embedded/.vscode/settings.json
+++ b/embedded/.vscode/settings.json
@@ -28,7 +28,8 @@
         "pm100.h": "c",
         "adc.h": "c",
         "can_tx_thread.h": "c",
-        "init.h": "c"
+        "init.h": "c",
+        "can_rx_thread.h": "c"
     },
     "cortex-debug.variableUseNaturalFormat": true,
 }

--- a/embedded/Core/Src/app_threadx.c
+++ b/embedded/Core/Src/app_threadx.c
@@ -28,11 +28,6 @@
 #include "init.h"
 #include "trace.h"
 
-#include "can_tx_thread.h"
-#include "can_rx_thread.h"
-#include "control_thread.h"
-#include "fault_state_thread.h"
-#include "sensor_thread.h"
 #include "messaging_system.h"
 
 #include "pm100.h"
@@ -82,56 +77,8 @@ UINT App_ThreadX_Init(VOID *memory_ptr)
   /* USER CODE BEGIN App_ThreadX_Init */
 
     init_pre_rtd(byte_pool);
-
-    /*************************
-     * Other initialisation
-     **************************/
-
-    // RTC timestamps
-    if (ret == TX_SUCCESS)
-    {
-        rtc_time_init();
-    }
-
-    // message system
-    if (ret == TX_SUCCESS)
-    {
-        ret = message_system_init();
-    }
-
-    if (ret == TX_SUCCESS)
-    {
-        pm100_status_t status = pm100_init();
-        
-        if (status != PM100_OK)
-        {
-            ret = TX_START_ERROR;
-        }
-    }
-
-
-    /*************************
-     * Ready-to-drive wait
-     **************************/
-    if (ret == TX_SUCCESS)
-    {
-        wait_for_ready_to_drive();
-    }
-    else 
-    {
-        enter_fault_state();
-    }
-
-    /*************************
-     * Start TraceX
-     **************************/
-    #if TRACEX_ENABLE
-    if (ret == TX_SUCCESS)
-    {
-        ret = trace_init();
-        trace_log_event(TRACE_READY_TO_DRIVE_EVENT, 0, 0, 0, 0);
-    }
-    #endif
+    wait_for_ready_to_drive();
+    init_post_rtd();
 
   /* USER CODE END App_ThreadX_Init */
 

--- a/embedded/Core/Src/app_threadx.c
+++ b/embedded/Core/Src/app_threadx.c
@@ -77,7 +77,7 @@ UINT App_ThreadX_Init(VOID *memory_ptr)
   /* USER CODE BEGIN App_ThreadX_Init */
 
     init_pre_rtd(byte_pool);
-    wait_for_ready_to_drive();
+    rtd_wait();
     init_post_rtd();
 
   /* USER CODE END App_ThreadX_Init */

--- a/embedded/Core/Src/app_threadx.c
+++ b/embedded/Core/Src/app_threadx.c
@@ -26,13 +26,8 @@
 
 #include "config.h"
 #include "init.h"
-#include "trace.h"
-
-#include "messaging_system.h"
-
-#include "pm100.h"
-#include "rtc_time.h"
 #include "ready_to_drive.h"
+#include "trace.h"
 
 /* USER CODE END Includes */
 

--- a/embedded/Core/Src/app_threadx.c
+++ b/embedded/Core/Src/app_threadx.c
@@ -25,6 +25,7 @@
 /* USER CODE BEGIN Includes */
 
 #include "config.h"
+#include "init.h"
 #include "trace.h"
 
 #include "can_tx_thread.h"
@@ -76,89 +77,11 @@ UINT App_ThreadX_Init(VOID *memory_ptr)
   TX_BYTE_POOL *byte_pool = (TX_BYTE_POOL*)memory_ptr;
 
   /* USER CODE BEGIN App_ThreadX_MEM_POOL */
-    (void)byte_pool;
   /* USER CODE END App_ThreadX_MEM_POOL */
 
   /* USER CODE BEGIN App_ThreadX_Init */
 
-    VOID* stack_ptr;	// pointer to allocated memory for thread stack
-
-    /**************************
-     * Control thread creation
-     **************************/
-
-    ret = tx_byte_allocate(memory_ptr, &stack_ptr, CONTROL_THREAD_STACK_SIZE, TX_NO_WAIT);
-
-    if (ret == TX_SUCCESS)
-    {
-        ret = tx_thread_create(&control_thread, CONTROL_THREAD_NAME, control_thread_entry, 0, stack_ptr,
-                    CONTROL_THREAD_STACK_SIZE, CONTROL_THREAD_PRIORITY, CONTROL_THREAD_PREEMPTION_THRESHOLD,
-                    TX_NO_TIME_SLICE, TX_AUTO_START);
-    }
-
-    /*************************
-     * CAN thread creation
-     **************************/
-
-    if (ret == TX_SUCCESS)
-    {
-        ret = tx_byte_allocate(memory_ptr, &stack_ptr, CAN_TX_THREAD_STACK_SIZE, TX_NO_WAIT);
-    }
-
-    if (ret == TX_SUCCESS)
-    {
-        ret = tx_thread_create(&can_tx_thread, CAN_TX_THREAD_NAME, can_tx_thread_entry, 0, stack_ptr,
-                    CAN_TX_THREAD_STACK_SIZE, CAN_THREAD_PRIORITY, CAN_TX_THREAD_PREEMPTION_THRESHOLD,
-                    TX_NO_TIME_SLICE, TX_AUTO_START);
-    }
-
-    if (ret == TX_SUCCESS)
-    {
-        ret = tx_byte_allocate(memory_ptr, &stack_ptr, CAN_RX_THREAD_STACK_SIZE, TX_NO_WAIT);
-    }
-
-    if (ret == TX_SUCCESS)
-    {
-        ret = tx_thread_create(&can_rx_thread, CAN_RX_THREAD_NAME, can_rx_thread_entry, 0, stack_ptr,
-                    CAN_RX_THREAD_STACK_SIZE, CAN_RX_THREAD_PRIORITY, CAN_RX_THREAD_PREEMPTION_THRESHOLD,
-                    TX_NO_TIME_SLICE, TX_AUTO_START);
-    }
-
-    /*************************
-     * Sensor thread creation
-     **************************/
-
-    if (ret == TX_SUCCESS)
-    {
-        ret = tx_byte_allocate(memory_ptr, &stack_ptr, SENSOR_THREAD_STACK_SIZE, TX_NO_WAIT);
-
-    }
-
-    if (ret == TX_SUCCESS)
-    {
-        ret = tx_thread_create(&sensor_thread, SENSOR_THREAD_NAME, sensor_thread_entry, 0, stack_ptr,
-                    SENSOR_THREAD_STACK_SIZE, SENSOR_THREAD_PRIORITY, SENSOR_THREAD_PREEMPTION_THRESHOLD,
-                    TX_NO_TIME_SLICE, TX_AUTO_START);
-    }
-
-    /*************************
-     * Fault thread creation
-     **************************/
-
-    // allocate memory for fault state thread from application memory pool
-    if (ret == TX_SUCCESS)
-    {
-        ret = tx_byte_allocate(memory_ptr, &stack_ptr, FAULT_STATE_THREAD_STACK_SIZE, TX_NO_WAIT);
-    }
-
-    // create fault state thread
-    // -> don't auto start it
-    if (ret == TX_SUCCESS)
-    {
-        ret = tx_thread_create(&fault_state_thread, FAULT_STATE_THREAD_NAME, fault_state_thread_entry, 0, stack_ptr,
-                    FAULT_STATE_THREAD_STACK_SIZE, FAULT_STATE_THREAD_PRIORITY, FAULT_STATE_THREAD_PREEMPTION_THRESHOLD,
-                    TX_NO_TIME_SLICE, TX_DONT_START);
-    }
+    init_pre_rtd(byte_pool);
 
     /*************************
      * Other initialisation
@@ -196,15 +119,7 @@ UINT App_ThreadX_Init(VOID *memory_ptr)
     }
     else 
     {
-        tx_thread_resume(&fault_state_thread);
-    }
-
-    /*************************
-     * Post ready-to-drive
-     **************************/
-    if (ret == TX_SUCCESS)
-    {
-        ret = can_rx_init();
+        enter_fault_state();
     }
 
     /*************************

--- a/embedded/Makefile
+++ b/embedded/Makefile
@@ -80,6 +80,7 @@ LDFLAGS = $(MCU) -specs=nano.specs -T$(LDSCRIPT) $(LIBDIR) $(LIBS) -Wl,-Map=$(BU
 ######################################
 
 C_SOURCES =  \
+SUFST/Src/init.c \
 SUFST/Src/config_rules.c \
 SUFST/Src/ready_to_drive.c \
 SUFST/Src/CAN/can_device_state.c \

--- a/embedded/SUFST/Inc/Threads/can_rx_thread.h
+++ b/embedded/SUFST/Inc/Threads/can_rx_thread.h
@@ -9,25 +9,10 @@
 #define CAN_RX_THREAD_H
 
 #include "tx_api.h"
-#include "config.h"
-
-#include "can_device_state.h"
 #include "fdcan.h"
 
-#define CAN_RX_THREAD_STACK_SIZE            1024
-#define CAN_RX_THREAD_PREEMPTION_THRESHOLD  CAN_RX_THREAD_PRIORITY
-#define CAN_RX_THREAD_NAME                  "CAN Rx Thread"
-
-/**
- * @brief CAN receive thread
- */
-extern TX_THREAD can_rx_thread;
-
-/*
- * function prototypes
- */
-void can_rx_thread_entry(ULONG thread_input);
-UINT can_rx_init();
+UINT can_rx_thread_init(TX_BYTE_POOL* stack_pool_ptr);
+UINT can_rx_thread_terminate();
 void HAL_FDCAN_RxFifo0Callback(FDCAN_HandleTypeDef *hfdcan, uint32_t RxFifo0ITs);
 
 #endif

--- a/embedded/SUFST/Inc/Threads/can_tx_thread.h
+++ b/embedded/SUFST/Inc/Threads/can_tx_thread.h
@@ -10,14 +10,7 @@
 
 #include "tx_api.h"
 
-#define CAN_TX_THREAD_STACK_SIZE			1024
-#define CAN_TX_THREAD_PREEMPTION_THRESHOLD	CAN_THREAD_PRIORITY
-#define CAN_TX_THREAD_NAME					"CAN Tx Thread"
-
-// expose thread instance to files including this header
-extern TX_THREAD can_tx_thread;
-
-// function prototypes
-void can_tx_thread_entry(ULONG thread_input);
+UINT can_tx_thread_init(TX_BYTE_POOL* stack_pool_ptr);
+UINT can_tx_thread_terminate();
 
 #endif

--- a/embedded/SUFST/Inc/Threads/control_thread.h
+++ b/embedded/SUFST/Inc/Threads/control_thread.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  * @file   control_thread.h
- * @author Tim Brewis (tab1g19@soton.ac.uk)
+ * @author Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
  * @date   2021-11-09
  * @brief  Control thread definitions and prototypes
  ***************************************************************************/
@@ -9,17 +9,8 @@
 #define CONTROL_THREAD_H
 
 #include "tx_api.h"
-#include "config.h"
 
-// LED thread definitions
-#define CONTROL_THREAD_STACK_SIZE			1024
-#define CONTROL_THREAD_PREEMPTION_THRESHOLD CONTROL_THREAD_PRIORITY
-#define CONTROL_THREAD_NAME					"Control Thread"
-
-// expose thread instance to files including this header
-extern TX_THREAD control_thread;
-
-// function prototypes
-void control_thread_entry(ULONG thread_input);
+UINT control_thread_init(TX_BYTE_POOL* stack_pool_ptr);
+UINT control_thread_terminate();
 
 #endif

--- a/embedded/SUFST/Inc/Threads/fault_state_thread.h
+++ b/embedded/SUFST/Inc/Threads/fault_state_thread.h
@@ -1,26 +1,16 @@
 /***************************************************************************
  * @file   fault_state_thread.h
- * @author Tim Brewis (tab1g19@soton.ac.uk)
+ * @author Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
  * @date   2022-03-15
- * @brief  Fault state thread
+ * @brief  Fault state thread definitions and prototypes
  ***************************************************************************/
 
 #ifndef FAULT_STATE_THREAD_H
 #define FAULT_STATE_THREAD_H
 
 #include "tx_api.h"
-#include "config.h"
 
-// LED thread definitions
-#define FAULT_STATE_THREAD_STACK_SIZE				512
-#define FAULT_STATE_THREAD_PREEMPTION_THRESHOLD		FAULT_STATE_THREAD_PRIORITY
-#define FAULT_STATE_THREAD_NAME						"Fault State Thread"
-
-// expose thread instance to files including this header
-extern TX_THREAD fault_state_thread;
-
-// function prototypes
+UINT fault_state_thread_init();
 void enter_fault_state();
-void fault_state_thread_entry(ULONG thread_input);
 
 #endif

--- a/embedded/SUFST/Inc/config.h
+++ b/embedded/SUFST/Inc/config.h
@@ -43,7 +43,7 @@
 #define FAULT_STATE_THREAD_PRIORITY	        0		// maximum priority
 #define SENSOR_THREAD_PRIORITY		        3
 #define CONTROL_THREAD_PRIORITY		        3
-#define CAN_THREAD_PRIORITY			        2
+#define CAN_TX_THREAD_PRIORITY			    2
 #define CAN_RX_THREAD_PRIORITY              4
 
 #define TRACEX_ENABLE                       0      // enable TraceX logging

--- a/embedded/SUFST/Inc/init.h
+++ b/embedded/SUFST/Inc/init.h
@@ -10,7 +10,7 @@
 
 #include "tx_api.h"
 
-void init_pre_rtd(TX_BYTE_POOL* stack_pool_ptr);
-void init_post_rtd();
+UINT init_pre_rtd(TX_BYTE_POOL* stack_pool_ptr);
+UINT init_post_rtd();
 
 #endif

--- a/embedded/SUFST/Inc/init.h
+++ b/embedded/SUFST/Inc/init.h
@@ -1,16 +1,16 @@
 /***************************************************************************
- * @file   sensor_thread.h
+ * @file   init.h
  * @author Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
- * @date   2021-11-30
- * @brief  Sensor thread
+ * @date   2022-05-20
+ * @brief  Initialisation function prototypes
  ***************************************************************************/
 
-#ifndef SENSOR_THREAD_H
-#define SENSOR_THREAD_H
+#ifndef INIT_H
+#define INIT_H
 
 #include "tx_api.h"
 
-UINT sensor_thread_init(TX_BYTE_POOL* stack_pool_ptr);
-UINT sensor_thread_terminate();
+void init_pre_rtd(TX_BYTE_POOL* stack_pool_ptr);
+void init_post_rtd();
 
 #endif

--- a/embedded/SUFST/Inc/ready_to_drive.h
+++ b/embedded/SUFST/Inc/ready_to_drive.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  * @file   ready_to_drive.h
- * @author Tim Brewis (tab1g19@soton.ac.uk)
+ * @author Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
  * @date   2022-03-10
  * @brief  Ready to drive function prototypes
  ***************************************************************************/
@@ -8,6 +8,6 @@
 #ifndef READY_TO_DRIVE_H
 #define READY_TO_DRIVE_H
 
-void wait_for_ready_to_drive();
+void rtd_wait();
 
 #endif

--- a/embedded/SUFST/Src/Threads/can_rx_thread.c
+++ b/embedded/SUFST/Src/Threads/can_rx_thread.c
@@ -65,13 +65,12 @@ UINT can_rx_thread_init(TX_BYTE_POOL* stack_pool_ptr)
     }
 
     // create semaphore
-    UINT status = tx_semaphore_create(&can_rx_semaphore, CAN_RX_SEMAPHORE_NAME, 0);
+    if (ret == TX_SUCCESS)
+    {
+        ret = tx_semaphore_create(&can_rx_semaphore, CAN_RX_SEMAPHORE_NAME, 0);
+    }   
 
-    // start CAN receive
-    HAL_FDCAN_Start(&hfdcan1); 
-    HAL_FDCAN_ActivateNotification(&hfdcan1, FDCAN_IT_RX_FIFO0_NEW_MESSAGE, 0);
-
-    return status;
+    return ret;
 }
 
 /**
@@ -94,10 +93,14 @@ void can_rx_thread_entry(ULONG thread_input)
     // not using input, prevent compiler warning
     (void) thread_input;
 
+    // start CAN receive
+    HAL_FDCAN_Start(&hfdcan1); 
+    HAL_FDCAN_ActivateNotification(&hfdcan1, FDCAN_IT_RX_FIFO0_NEW_MESSAGE, 0);
+
     // loop forever
     while (1)
     {
-        // wait for CAN receive eevent
+        // wait for CAN receive event
         if (tx_semaphore_get(&can_rx_semaphore, TX_WAIT_FOREVER) == TX_SUCCESS)
         {
             // read data

--- a/embedded/SUFST/Src/Threads/can_rx_thread.c
+++ b/embedded/SUFST/Src/Threads/can_rx_thread.c
@@ -6,11 +6,15 @@
  ***************************************************************************/
 
 #include "can_rx_thread.h"
+#include "config.h"
 #include "tx_api.h"
 
 #include "can_device_state.h"
 
-#define CAN_RX_SEMAPHORE_NAME   "CAN Rx Semaphore"
+#define CAN_RX_THREAD_STACK_SIZE            1024
+#define CAN_RX_THREAD_PREEMPTION_THRESHOLD  CAN_RX_THREAD_PRIORITY
+#define CAN_RX_THREAD_NAME                  "CAN Rx Thread"
+#define CAN_RX_SEMAPHORE_NAME               "CAN Rx Semaphore"
 
 /**
  * @brief CAN receive thread
@@ -23,6 +27,62 @@ TX_THREAD can_rx_thread;
  * @details Signalled by ISR to activate CAN receive thread
  */
 TX_SEMAPHORE can_rx_semaphore;
+
+/*
+ * function prototypes
+ */
+void can_rx_thread_entry(ULONG thread_input);
+
+/**
+ * @brief 		Initialise CAN receive thread
+ * 
+ * @param[in]	stack_pool_ptr 	Pointer to start of application stack area
+ * 
+ * @return 		See ThreadX return codes
+ */
+UINT can_rx_thread_init(TX_BYTE_POOL* stack_pool_ptr)
+{
+    // create thread
+    VOID* thread_stack_ptr;
+
+    UINT ret = tx_byte_allocate(stack_pool_ptr, 
+                                &thread_stack_ptr, 
+                                CAN_RX_THREAD_STACK_SIZE, 
+                                TX_NO_WAIT);
+
+    if (ret == TX_SUCCESS)
+    {
+        ret = tx_thread_create(&can_rx_thread, 
+                                CAN_RX_THREAD_NAME, 
+                                can_rx_thread_entry, 
+                                0,
+                                thread_stack_ptr,
+                                CAN_RX_THREAD_STACK_SIZE,
+                                CAN_RX_THREAD_PRIORITY,
+                                CAN_RX_THREAD_PREEMPTION_THRESHOLD,
+                                TX_NO_TIME_SLICE,
+                                TX_AUTO_START);
+    }
+
+    // create semaphore
+    UINT status = tx_semaphore_create(&can_rx_semaphore, CAN_RX_SEMAPHORE_NAME, 0);
+
+    // start CAN receive
+    HAL_FDCAN_Start(&hfdcan1); 
+    HAL_FDCAN_ActivateNotification(&hfdcan1, FDCAN_IT_RX_FIFO0_NEW_MESSAGE, 0);
+
+    return status;
+}
+
+/**
+ * @brief 	Terminate CAN receive thread
+ * 
+ * @return 	See ThreadX return codes
+ */
+UINT can_rx_thread_terminate()
+{
+	return tx_thread_terminate(&can_rx_thread);
+}
 
 /**
  * @brief       Thread entry function for CAN receive dispatch thread
@@ -55,23 +115,6 @@ void can_rx_thread_entry(ULONG thread_input)
             
         }
     }
-}
-
-/**
- * @brief  Initialise CAN receive service
- * 
- * @return TX_SUCCESS if successful, ThreadX error code otherwise 
- */
-UINT can_rx_init()
-{
-    // initialise CAN
-    // TODO: status codes
-    HAL_FDCAN_Start(&hfdcan1); 
-    HAL_FDCAN_ActivateNotification(&hfdcan1, FDCAN_IT_RX_FIFO0_NEW_MESSAGE, 0);
-
-    // create semaphore
-    UINT status = tx_semaphore_create(&can_rx_semaphore, CAN_RX_SEMAPHORE_NAME, 0);
-    return status;
 }
 
 /**

--- a/embedded/SUFST/Src/Threads/can_tx_thread.c
+++ b/embedded/SUFST/Src/Threads/can_tx_thread.c
@@ -13,10 +13,63 @@
 #include "pm100.h"
 #include "trace.h"
 
+#define CAN_TX_THREAD_STACK_SIZE			1024
+#define CAN_TX_THREAD_PREEMPTION_THRESHOLD	CAN_TX_THREAD_PRIORITY
+#define CAN_TX_THREAD_NAME					"CAN Tx Thread"
+
 /**
  * @brief Thread for CAN transmit
  */
 TX_THREAD can_tx_thread;
+
+/*
+ * function prototypes
+ */ 
+void can_tx_thread_entry(ULONG thread_input);
+
+/**
+ * @brief 		Initialise CAN transmit thread
+ * 
+ * @param[in]	stack_pool_ptr 	Pointer to start of application stack area
+ * 
+ * @return 		See ThreadX return codes
+ */
+UINT can_tx_thread_init(TX_BYTE_POOL* stack_pool_ptr)
+{
+	VOID* thread_stack_ptr;
+
+	UINT ret = tx_byte_allocate(stack_pool_ptr, 
+								&thread_stack_ptr,
+								CAN_TX_THREAD_STACK_SIZE,
+								TX_NO_WAIT);
+
+	if (ret == TX_SUCCESS)
+	{
+		ret = tx_thread_create(&can_tx_thread,
+								CAN_TX_THREAD_NAME,
+								can_tx_thread_entry,
+								0,
+								thread_stack_ptr,
+								CAN_TX_THREAD_STACK_SIZE,
+								CAN_TX_THREAD_PRIORITY,
+								CAN_TX_THREAD_PREEMPTION_THRESHOLD,
+								TX_NO_TIME_SLICE,
+								TX_AUTO_START);
+	}
+
+	return ret;
+}
+
+/**
+ * @brief 	Terminate CAN transmit thread
+ * 
+ * @return 	See ThreadX return codes
+ */
+UINT can_tx_thread_terminate()
+{
+	return tx_thread_terminate(&can_tx_thread);
+}
+
 
 /**
  * @brief Thread entry function for CAN transmit thread

--- a/embedded/SUFST/Src/Threads/fault_state_thread.c
+++ b/embedded/SUFST/Src/Threads/fault_state_thread.c
@@ -1,11 +1,12 @@
 /***************************************************************************
  * @file   fault_state_thread.c
- * @author Tim Brewis (tab1g19@soton.ac.uk)
+ * @author Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
  * @date   2022-03-15
- * @brief  Fault state thread
+ * @brief  Fault state thread implementation
  ***************************************************************************/
 
 #include "fault_state_thread.h"
+#include "config.h"
 
 #include "can_tx_thread.h"
 #include "can_rx_thread.h"
@@ -13,18 +14,51 @@
 #include "sensor_thread.h"
 #include "gpio.h"
 
+#define FAULT_STATE_THREAD_STACK_SIZE				512
+#define FAULT_STATE_THREAD_PREEMPTION_THRESHOLD		FAULT_STATE_THREAD_PRIORITY
+#define FAULT_STATE_THREAD_NAME						"Fault State Thread"
+
 /**
  * @brief Thread for fault state
  */
 TX_THREAD fault_state_thread;
 
-/**
- * @brief	Enter the fault state
+/*
+ * function prototypes
  */
-void enter_fault_state()
+void fault_state_thread_entry(ULONG thread_input);
+
+/**
+ * @brief 		Initialise fault state thread
+ * 
+ * @param[in]	stack_pool_ptr 	Pointer to start of application stack area
+ * 
+ * @return 		See ThreadX return codes
+ */
+UINT fault_state_thread_init(TX_BYTE_POOL* stack_pool_ptr)
 {
-	tx_thread_resume(&fault_state_thread);
-	tx_thread_relinquish();
+	VOID* thread_stack_ptr;
+
+	UINT ret = tx_byte_allocate(stack_pool_ptr, 
+								&thread_stack_ptr, 
+								FAULT_STATE_THREAD_STACK_SIZE, 
+								TX_NO_WAIT);
+
+    if (ret == TX_SUCCESS)
+    {
+        ret = tx_thread_create(&fault_state_thread, 
+								FAULT_STATE_THREAD_NAME, 
+								fault_state_thread_entry, 
+								0, 
+								thread_stack_ptr,
+                    			FAULT_STATE_THREAD_STACK_SIZE, 
+								FAULT_STATE_THREAD_PRIORITY, 
+								FAULT_STATE_THREAD_PREEMPTION_THRESHOLD,
+                    			TX_NO_TIME_SLICE, 
+								TX_DONT_START);
+    }
+
+	return ret;
 }
 
 /**
@@ -42,10 +76,10 @@ void fault_state_thread_entry(ULONG thread_input)
 
 	// shut down other threads
 	// note: this thread has the highest priority and will not be pre-empted
-	tx_thread_terminate(&sensor_thread);
-	tx_thread_terminate(&control_thread);
-	tx_thread_terminate(&can_tx_thread);
-	tx_thread_terminate(&can_rx_thread);
+	sensor_thread_terminate();
+	control_thread_terminate();
+	can_tx_thread_terminate();
+	can_rx_thread_terminate();
 
 	// loop forever, do not leave fault state
 	// flash the LED
@@ -55,4 +89,13 @@ void fault_state_thread_entry(ULONG thread_input)
 		tx_thread_sleep(TX_TIMER_TICKS_PER_SECOND / FAULT_STATE_LED_BLINK_RATE);
 	}
 
+}
+
+/**
+ * @brief	Enter the fault state
+ */
+void enter_fault_state()
+{
+	tx_thread_resume(&fault_state_thread);
+	tx_thread_relinquish();
 }

--- a/embedded/SUFST/Src/Threads/messaging_system.c
+++ b/embedded/SUFST/Src/Threads/messaging_system.c
@@ -1,6 +1,6 @@
 /***************************************************************************
  * @file   messaging.c
- * @author Tim Brewis (tab1g19@soton.ac.uk)
+ * @author Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
  * @date   2021-11-30
  * @brief  Inter-thread messaging system implementation
  ***************************************************************************/
@@ -77,7 +77,7 @@ UINT message_receive(VOID* dest_ptr, TX_QUEUE* queue_ptr)
  *
  * @note		The timestamp will overflow after around 49.7 days.
  *
- * @param[in]	timestamp_ptr	UINT pointer to message struct field to store timestamp in
+ * @param[in]	timestamp_ptr	Pointer to message struct field to store timestamp in
  */
 void message_set_timestamp(UINT* timestamp_ptr)
 {

--- a/embedded/SUFST/Src/init.c
+++ b/embedded/SUFST/Src/init.c
@@ -1,0 +1,67 @@
+/***************************************************************************
+ * @file   init.c
+ * @author Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
+ * @date   2022-05-20
+ * @brief  Initialisation function implementation
+ ***************************************************************************/
+
+#include "init.h"
+
+#include "can_rx_thread.h"
+#include "can_tx_thread.h"
+#include "control_thread.h"
+#include "fault_state_thread.h"
+#include "sensor_thread.h"
+
+UINT init_threads(TX_BYTE_POOL* stack_pool_ptr);
+
+/**
+ * @brief       Initialisation pre ready-to-drive
+ * 
+ * @param[in]   stack_pool_ptr  Pointer to start of application stack area
+ */
+void init_pre_rtd(TX_BYTE_POOL* stack_pool_ptr)
+{
+    init_threads(stack_pool_ptr);
+}
+
+/**
+ * @brief Initialisation post ready-to-drive
+ */
+void init_post_rtd()
+{
+
+}
+
+/**
+ * @brief       Create and initialise threads
+ * 
+ * @param[in]   stack_pool_ptr  Pointer to start of application stack area
+ * 
+ * @return      UINT: See ThreadX return codes
+ */
+UINT init_threads(TX_BYTE_POOL* stack_pool_ptr)
+{
+    UINT (*thread_init_funcs[])(TX_BYTE_POOL*) = {
+        can_rx_thread_init,
+        can_tx_thread_init,
+        control_thread_init,
+        fault_state_thread_init,
+        sensor_thread_init,
+    };
+
+    const UINT num_threads = sizeof(thread_init_funcs) / sizeof(thread_init_funcs[0]);
+    UINT ret = TX_SUCCESS;
+
+    for (UINT i = 0; i < num_threads; i++)
+    {
+        ret = thread_init_funcs[i](stack_pool_ptr);
+
+        if (ret != TX_SUCCESS)
+        {
+            break;
+        }
+    }
+
+    return ret;
+}

--- a/embedded/SUFST/Src/init.c
+++ b/embedded/SUFST/Src/init.c
@@ -17,6 +17,9 @@
 #include "pm100.h"
 #include "rtc_time.h"
 
+/*
+ * function prototypes
+ */
 UINT init_threads(TX_BYTE_POOL* stack_pool_ptr);
 
 /**

--- a/embedded/SUFST/Src/ready_to_drive.c
+++ b/embedded/SUFST/Src/ready_to_drive.c
@@ -1,6 +1,6 @@
 /***************************************************************************
  * @file   ready_to_drive.c
- * @author Tim Brewis (tab1g19@soton.ac.uk)
+ * @author Tim Brewis (@t-bre, tab1g19@soton.ac.uk)
  * @date   2022-03-10
  * @brief  Ready to drive logic implementation
  ***************************************************************************/
@@ -18,24 +18,24 @@
 /*
  * function prototypes
  */
-static bool ready_to_drive_state();
+static bool rtd_pin_state();
 static void sound_buzzer();
 
 /**
  * @brief Wait for ready-to-drive signal to become active
  */
-void wait_for_ready_to_drive()
+void rtd_wait()
 {
 	// red LED on
 	HAL_GPIO_WritePin(RED_LED_GPIO_Port, RED_LED_Pin, GPIO_PIN_SET);
 
 	// wait for active high
-	while (!ready_to_drive_state());
+	while (!rtd_pin_state());
 
 	// if ready to drive overridden ('USER' button input)
 	// wait for button to be released
 #if (READY_TO_DRIVE_OVERRIDE)
-	while (ready_to_drive_state());
+	while (rtd_pin_state());
 #endif
 
 	// disable inverter (lockout)
@@ -56,7 +56,7 @@ void wait_for_ready_to_drive()
  *
  * @return 	True if ready-to-drive signal active, false otherwise
  */
-bool ready_to_drive_state()
+bool rtd_pin_state()
 {
 #if (READY_TO_DRIVE_OVERRIDE)
 	return HAL_GPIO_ReadPin(USER_BUTTON_GPIO_Port, USER_BUTTON_Pin) == GPIO_PIN_SET;


### PR DESCRIPTION
### Changes
- Create two functions for pre and post ready-to-drive initialisation.
- Move module/thread initialisation to appropriate one of these functions.
- Create module/thread initialisation functions for those that didn't already have them.
- Improve modularity of thread related code by hiding implementation details behind header interface.