### PR TITLE
chore(github)!: update contributing guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,0 @@
-## SUFST
-- [SUFST contributing guidelines](https://docs.sufst.co.uk/en/latest/general/software-tools/git/guidelines.html#guidelines)
-
-## VCU Extras
-- [Embedded C coding guidelines for the VCU](https://github.com/sufst/vcu/wiki/Embedded-C-Coding-Guidelines).
-- [Squash merge](https://docs.gitlab.com/ee/user/project/merge_requests/squash_and_merge.html) all pull requests to keep the commit history on the `main` branch clean.

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,50 @@
 # VCU - Vehicle Control Unit
 The VCU is responsible for taking driver throttle inputs and communicating with the inverter.
 
+## Contributing
+
+### Conventional Commits
+Commits should follow the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/) with the format:
+```
+<type>(<scope>): <subject>
+```
+
+`<type>` __must__ be one of:
+| Type       | Description                                                         |
+|------------|---------------------------------------------------------------------|
+| `feat`     | New features                                                        |
+| `fix`      | Bug fixes                                                           |
+| `refactor` | Refactors (rewriting/restructuring code without changing behaviour) |
+| `perf`     | Refactors specifically to improve performance                       |
+| `style`    | Code formatting, whitespace etc                                     |
+| `test`     | New tests or changes to existing tests                              |
+| `docs`     | Changes to documentation                                            |
+| `build`    | Changes to build system, compilation, toolchain                     |      
+| `chore`    | |
+
+`<scope>` should be a single word describing a part of the system such as (but not limited to):
+| Scope      | Description                                                    |
+|------------|----------------------------------------------------------------|
+| `can`      | Communication with devices on the CAN bus                      |
+| `control`  | Control algorithms (throttle mapping, traction control...)     |
+| `drs`      | Drag reduction system                                          |
+| `io`       | Reading/writing/configuring general I/O                        |
+| `rtos`     | Real-time operating system (configuration, thread creation...) |
+| `safety`   | Safety checks, fault handling, ready-to-drive logic            |
+| `sensors`  | Sensor inputs                                                  |
+
+`<subject>` should written as "lowercase, imperative, present tense" (e.g. _'create control thread'_ or _'add init.c to Makefile'_).
+
+### Code Formatting
+Code should be formatted before committing using [`trunk`](https://docs.trunk.io) with the command:
+```
+trunk fmt
+```
+Install `trunk` for Linux or macOS with:
+```
+curl https://get.trunk.io -fsSL | bash
+```
+Alternatively, install the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=Trunk.io).
 
 ## Useful Resources
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -20,7 +20,8 @@ Commits (and issue/pull request titles) should follow the [conventional commits 
 | `test`     | New tests or changes to existing tests                              |
 | `docs`     | Changes to documentation                                            |
 | `build`    | Changes to build system, compilation, toolchain                     |      
-| `chore`    | |
+| `chore`    | Chores (internal/organisational changes, updating .gitignore, etc)  |
+| `misc`     | Anything which absolutely does not match any of the other types     |
 
 `<scope>` should be a single word describing a part of the system such as (but not limited to):
 | Scope      | Description                                                    |

--- a/.github/README.md
+++ b/.github/README.md
@@ -10,7 +10,6 @@
 
 The VCU is responsible for taking driver throttle inputs and communicating with the inverter.
 
-
 # Contributing
 
 ## Conventional Commits
@@ -45,6 +44,12 @@ Commits (and issue/pull request titles) should follow the [conventional commits 
 | `sensors`  | Sensor inputs                                                  |
 
 `<subject>` should written as "lowercase, imperative, present tense" (e.g. _'create control thread'_ or _'add init.c to Makefile'_).
+
+## Branch Names
+Branches should be named beginning with the `<type>` for the corresponding issue, followed by a `/` and a dash-separated title briefly describing the overall purpose of the branch:
+```
+<type>/dash-separated-title
+```
 
 ## Code Formatting
 Code should be formatted before committing using [`trunk`](https://docs.trunk.io) with the command:

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,9 +1,19 @@
-# VCU - Vehicle Control Unit
+<h1 align="center"> VCU - Vehicle Control Unit </h2>
+
+# Table of Contents
+- [About](#about)  
+- [Contributing](#contributing)   
+- [Useful Resources](#useful-resources)   
+- [Related Projects](#related-projects)   
+
+# About
+
 The VCU is responsible for taking driver throttle inputs and communicating with the inverter.
 
-## Contributing
 
-### Conventional Commits
+# Contributing
+
+## Conventional Commits
 Commits (and issue/pull request titles) should follow the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/) with the format:
 ```
 <type>(<scope>): <subject>
@@ -36,7 +46,7 @@ Commits (and issue/pull request titles) should follow the [conventional commits 
 
 `<subject>` should written as "lowercase, imperative, present tense" (e.g. _'create control thread'_ or _'add init.c to Makefile'_).
 
-### Code Formatting
+## Code Formatting
 Code should be formatted before committing using [`trunk`](https://docs.trunk.io) with the command:
 ```
 trunk fmt
@@ -47,7 +57,7 @@ curl https://get.trunk.io -fsSL | bash
 ```
 Alternatively, install the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=Trunk.io).
 
-## Useful Resources
+# Useful Resources
 
 Documentation and rules:
 - [VCU Wiki](https://github.com/sufst/vcu/wiki)
@@ -68,7 +78,7 @@ CAN / inverter:
 - [Cascadia Motion CAN Protocol](https://app.box.com/s/vf9259qlaadhzxqiqrt5cco8xpsn84hk/file/27334613044)
 
 
-## Related Projects
+# Related Projects
 
 - [VCU Driver Profiles App](https://github.com/sufst/vcu-driver-profile)
 - [VCU Breakout Board](https://github.com/sufst/vcu-breakout)

--- a/.github/README.md
+++ b/.github/README.md
@@ -4,7 +4,7 @@ The VCU is responsible for taking driver throttle inputs and communicating with 
 ## Contributing
 
 ### Conventional Commits
-Commits should follow the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/) with the format:
+Commits (and issue/pull request titles) should follow the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/) with the format:
 ```
 <type>(<scope>): <subject>
 ```


### PR DESCRIPTION
### Changes
- Suggest use of [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) from now on for commit messages, issue titles and PR titles.
- Define commit types and scopes in new README contributing guidelines.
- Remove old contributing guidelines.
