### PR TITLE
feat(rtd): add BPS check to RTD procedure

### DIFF
--- a/embedded/SUFST/Inc/bps.h
+++ b/embedded/SUFST/Inc/bps.h
@@ -8,9 +8,11 @@
 #ifndef BPS_H
 #define BPS_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 void bps_init();
 uint32_t bps_read();
+bool bps_fully_pressed();
 
 #endif

--- a/embedded/SUFST/Inc/config.h
+++ b/embedded/SUFST/Inc/config.h
@@ -27,7 +27,7 @@
  * ready-to-drive
  ***************************************************************************/
 
-#define READY_TO_DRIVE_OVERRIDE		        1		// set to 0 to use the 'USER' button as the ready-to-drive signal
+#define READY_TO_DRIVE_OVERRIDE		        0		// set to 0 to use the 'USER' button as the ready-to-drive signal
 #define READY_TO_DRIVE_BUZZER_TIME	        2500	// in ms
 
 /***************************************************************************
@@ -67,13 +67,13 @@
  ***************************************************************************/
 
 #define APPS_DISABLE_DIFF_CHECK             1       // disable check for discrepancy between APPS inputs
-#define APPS_DISABLE_BOUNDS_CHECK           1       // disable check for APPS ADC reading out of bounds
+#define APPS_DISABLE_SCS_CHECK              1       // disable check for APPS ADC reading out of bounds
 
 #define APPS_ADC_RESOLUTION                 16      // resolution of raw APPS input from ADC
 #define APPS_SCALED_RESOLUTION              10      // scaled (truncated) APPS 
 
 #define APPS_MAX_DIFF_FRACTION              0.025f  // maximum allowable difference between APPS inputs as a fraction of scaled range
-#define APPS_OUTSIDE_BOUNDS_FRACTION        0.01f  // fraction of full ADC range above/below ADC min/max considered 'out of bounds'
+#define APPS_OUTSIDE_BOUNDS_FRACTION        0.01f   // fraction of full ADC range above/below ADC min/max considered 'out of bounds'
 
 #define APPS_1_ADC_MIN                      5000    //  minimum raw ADC reading for APPS  channel 1
 #define APPS_2_ADC_MIN                      5000    // ^                                ^ channel 2
@@ -84,15 +84,18 @@
  * BPS - brake pressure sensor
  ***************************************************************************/
 
+#define BPS_DISABLE_SCS_CHECK               0       // disable check for BPS ADC reading out of bounds
+
 #define BPS_ADC_MIN                         200     // minimum raw ADC reading for BPS
-#define BPS_ADC_MAX                         5000    // maximum raw ADC reading for BPS
+#define BPS_ADC_MAX                         4000    // maximum raw ADC reading for BPS
 #define BPS_SCALED_RESOLUTION               10      // resolution of scaled BPS input
+#define BPS_FULLY_PRESSED_THRESHOLD         0.95f   // fraction of BPS full range beyond which it is considered to be fully pressed
 
 /***************************************************************************
  * SCS - safety critical signals
  ***************************************************************************/
 
-#define SCS_OUTSIDE_BOUNDS_FRACTION         0.01f   // fraction of full ADC range above/below ADC min/max considered 'out of bounds'
+#define SCS_OUTSIDE_BOUNDS_FRACTION         0.05f   // fraction of full ADC range above/below ADC min/max considered 'out of bounds'
 
 /***************************************************************************
  * testbenches

--- a/embedded/SUFST/Src/apps.c
+++ b/embedded/SUFST/Src/apps.c
@@ -66,19 +66,23 @@ uint32_t apps_read()
     {
         inputs[i] = scs_read(&apps_signals[i]);
 
+#if !APPS_DISABLE_SCS_CHECK
         if (!scs_validate(&apps_signals[i]))
         {
             critical_fault(CRITICAL_FAULT_SCS_OUTSIDE_BOUNDS);
             inputs[i] = 0;
         }
+#endif
 
         accumulator += inputs[i];
     }
 
+#if !APPS_DISABLE_DIFF_CHECK
     if (!apps_inputs_agree(inputs))
     {
         critical_fault(CRITICAL_FAULT_APPS_INPUT_DISCREPANCY);
     }
+#endif
 
     return accumulator / num_inputs;
 }

--- a/embedded/SUFST/Src/bps.c
+++ b/embedded/SUFST/Src/bps.c
@@ -40,10 +40,28 @@ uint32_t bps_read()
 {
     uint32_t reading = scs_read(&bps_signal);
 
+#if !BPS_DISABLE_SCS_CHECK
     if (!scs_validate(&bps_signal))
     {
         critical_fault(CRITICAL_FAULT_SCS_OUTSIDE_BOUNDS);
     }
+#endif
 
     return reading;
+}
+
+/**
+ * @brief   Checks if BPS is fully pressed
+ * 
+ * @return  true    BPS is fully pressed
+ * @return  false   BPS is not fully pressed
+ */
+bool bps_fully_pressed()
+{
+    const uint32_t bps_max = (1 << BPS_SCALED_RESOLUTION) - 1;
+    const uint32_t bps_threshold = bps_max * BPS_FULLY_PRESSED_THRESHOLD;
+
+    uint32_t bps_input = bps_read();
+
+    return bps_input > bps_threshold;
 }

--- a/embedded/SUFST/Src/ready_to_drive.c
+++ b/embedded/SUFST/Src/ready_to_drive.c
@@ -12,6 +12,7 @@
 #include "config.h"
 #include "tx_api.h"
 
+#include "bps.h"
 #include "gpio.h"
 
 #include "pm100.h"
@@ -30,7 +31,7 @@ void rtd_wait()
     HAL_GPIO_WritePin(RED_LED_GPIO_Port, RED_LED_Pin, GPIO_PIN_SET);
 
     // wait for active high
-    while (!rtd_input_active())
+    while (!(rtd_input_active() && bps_fully_pressed()))
         ;
 
         // if ready to drive overridden ('USER' button input)


### PR DESCRIPTION
### Changes
- Add configuration setting to disable SCS checks for APPS inputs when debugging.
- Add configuration settings for BPS.
- Check for BPS fully pressed as well as RTD signal before entering ready-to-drive state.

### Fixed Issues
Closes #128 
