### PR TITLE
feat(bps): add config option to skip BPS check during RTD

### DIFF
--- a/embedded/SUFST/Inc/config.h
+++ b/embedded/SUFST/Inc/config.h
@@ -28,6 +28,7 @@
  ***************************************************************************/
 
 #define READY_TO_DRIVE_OVERRIDE		        1		// set to 0 to use the 'USER' button as the ready-to-drive signal
+#define READY_TO_DRIVE_IGNORE_BPS           1
 #define READY_TO_DRIVE_BUZZER_TIME	        2500	// in ms
 
 /***************************************************************************
@@ -48,7 +49,8 @@
 #define WATCHDOG_THREAD_PRIORITY_ELEVATED   0       // elevated for critical fault handling
 #define INIT_THREAD_PRIORITY                0
 
-#define TRACEX_ENABLE                       0       // enable TraceX logging
+#define TRACEX_ENABLE                       1
+       // enable TraceX logging
 
 /***************************************************************************
  * CAN / inverter

--- a/embedded/SUFST/Src/Threads/sensor_thread.c
+++ b/embedded/SUFST/Src/Threads/sensor_thread.c
@@ -17,9 +17,9 @@
 #include "adc.h"
 #include "apps.h"
 #include "gpio.h"
-#include "shutdown.h"
 
 #include "control_thread.h"
+#include "shutdown.h"
 
 #define SENSOR_THREAD_STACK_SIZE           1024
 #define SENSOR_THREAD_PREEMPTION_THRESHOLD SENSOR_THREAD_PRIORITY

--- a/embedded/SUFST/Src/bps.c
+++ b/embedded/SUFST/Src/bps.c
@@ -52,7 +52,7 @@ uint32_t bps_read()
 
 /**
  * @brief   Checks if BPS is fully pressed
- * 
+ *
  * @return  true    BPS is fully pressed
  * @return  false   BPS is not fully pressed
  */

--- a/embedded/SUFST/Src/init.c
+++ b/embedded/SUFST/Src/init.c
@@ -7,6 +7,10 @@
 
 #include "init.h"
 
+#include "config.h"
+
+#include "trace.h"
+
 #include "apps.h"
 #include "bps.h"
 

--- a/embedded/SUFST/Src/ready_to_drive.c
+++ b/embedded/SUFST/Src/ready_to_drive.c
@@ -30,9 +30,13 @@ void rtd_wait()
 {
     HAL_GPIO_WritePin(RED_LED_GPIO_Port, RED_LED_Pin, GPIO_PIN_SET);
 
-    // wait for active high
+#if !READY_TO_DRIVE_IGNORE_BPS
     while (!(rtd_input_active() && bps_fully_pressed()))
         ;
+#else
+    while (!rtd_input_active())
+        ;
+#endif
 
         // if ready to drive overridden ('USER' button input)
         // wait for button to be released

--- a/embedded/SUFST/Src/shutdown.c
+++ b/embedded/SUFST/Src/shutdown.c
@@ -8,11 +8,12 @@
 #include "shutdown.h"
 
 #include "fault.h"
+
 #include "gpio.h"
 
 /**
  * @brief   Check if shutdown fault has occurred
- * 
+ *
  * @note    Shutdown is active low
  */
 void check_shutdown()


### PR DESCRIPTION
### Changes
- Add option in `config.h` to ignore requirement for BPS to be fully pressed to enter RTD.

### Fixed Issue(s)
N/A

### Checklist
- [x] Code has been tested on STM32 hardware.
- [x] Changes do not generate any new compiler warnings.
- [x] Code has been formatted using `trunk fmt`.
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.
