### PR TITLE
chore(trunk): update cppcheck config

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -20,7 +20,17 @@ plugins:
       uri: https://github.com/trunk-io/plugins
 lint:
   definitions:
-    - name: cppcheck # MISRA C checker
+    - name: cppcheck
+      files: [c]
+      commands:
+        - output: regex
+          success_codes: [0]
+          parse_regex: '((?P<path>.*):(?P<line>\d+):(?P<col>\d+): style: (?P<message>.*)) \[(?P<code>.*)\]'
+          run: cppcheck --enable=all --suppress=unusedFunction --cppcheck-build-dir=./cppcheck ${target}
+          read_output_from: stderr
+          run_linter_from: workspace
+          run_when: [cli, lsp, monitor, ci]
+    - name: cppcheck-misra # MISRA C checker
       files: [c]
       commands:
         - output: regex
@@ -29,16 +39,18 @@ lint:
           run: cppcheck --addon=./.trunk/config/misra.json --cppcheck-build-dir=./cppcheck ${target}
           read_output_from: stderr
           run_linter_from: workspace
-          run_when: [cli, lsp, monitor, ci]
+          run_when: [cli]
   enabled:
     - cppcheck@SYSTEM
     - clang-format@14.0.0
-    # - git-diff-check@SYSTEM
     - gitleaks@8.13.0
     - markdownlint@0.32.2
     - prettier@2.7.1
+  disabled:
+    - cppcheck-misra@SYSTEM
+    - git-diff-check@SYSTEM
   ignore:
-    - linters: [clang-format, gitleaks, cppcheck]
+    - linters: [clang-format, gitleaks, cppcheck, cppcheck-misra]
       paths:
         - src/AZURE_RTOS/**
         - src/Core/**

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,6 +37,6 @@
     "apps.h": "c",
     "limits": "c",
     "ready_to_drive.h": "c"
-},
+  },
   "cortex-debug.variableUseNaturalFormat": true
 }

--- a/src/SUFST/Inc/CAN/rtcan.h
+++ b/src/SUFST/Inc/CAN/rtcan.h
@@ -119,7 +119,7 @@ rtcan_status_t rtcan_start(rtcan_handle_t* rtcan_h);
 rtcan_status_t rtcan_transmit(rtcan_handle_t* rtcan_h, rtcan_msg_t* msg_ptr);
 
 rtcan_status_t rtcan_handle_tx_mailbox_callback(rtcan_handle_t* rtcan_h,
-                                                CAN_HandleTypeDef* can_h);
+                                                const CAN_HandleTypeDef* can_h);
 
 uint32_t rtcan_get_error(rtcan_handle_t* rtcan_h);
 

--- a/src/SUFST/Inc/vcu.h
+++ b/src/SUFST/Inc/vcu.h
@@ -12,10 +12,11 @@
 
 #include "tx_api.h"
 
+#include "rtcan.h"
+
 #include "can.h"
 #include "canbc.h"
 #include "driver_control.h"
-#include "rtcan.h"
 #include "ts_control.h"
 
 /*

--- a/src/SUFST/Src/CAN/rtcan.c
+++ b/src/SUFST/Src/CAN/rtcan.c
@@ -188,7 +188,7 @@ rtcan_status_t rtcan_transmit(rtcan_handle_t* rtcan_h, rtcan_msg_t* msg_ptr)
  * @param[in]   can_h       CAN handle passed to HAL callback
  */
 rtcan_status_t rtcan_handle_tx_mailbox_callback(rtcan_handle_t* rtcan_h,
-                                                CAN_HandleTypeDef* can_h)
+                                                const CAN_HandleTypeDef* can_h)
 {
     if (rtcan_h->hcan == can_h)
     {

--- a/src/SUFST/Src/apps.c
+++ b/src/SUFST/Src/apps.c
@@ -25,7 +25,7 @@ scs_t apps_signals[2];
 /*
  * function prototypes
  */
-bool apps_inputs_agree(uint32_t inputs[2]);
+bool apps_inputs_agree(const uint32_t inputs[2]);
 
 /**
  * @brief   Initialises APPS inputs
@@ -95,7 +95,7 @@ uint32_t apps_read()
  * @return      true    The inputs agree
  * @return      false   The inputs differ significantly
  */
-bool apps_inputs_agree(uint32_t inputs[2])
+bool apps_inputs_agree(const uint32_t inputs[2])
 {
     uint32_t diff = (inputs[1] > inputs[0]) ? inputs[1] - inputs[0]
                                             : inputs[0] - inputs[1];

--- a/src/SUFST/Src/driver_control.c
+++ b/src/SUFST/Src/driver_control.c
@@ -10,9 +10,10 @@
 
 #include "config.h"
 
-#include "Test/testbench.h"
 #include "apps.h"
 #include "bps.h"
+
+#include "Test/testbench.h"
 
 /*
  * macro constants

--- a/src/SUFST/Src/init.c
+++ b/src/SUFST/Src/init.c
@@ -13,6 +13,7 @@
 
 #include "apps.h"
 #include "bps.h"
+
 #include "watchdog_thread.h"
 
 /**

--- a/src/SUFST/Src/ready_to_drive.c
+++ b/src/SUFST/Src/ready_to_drive.c
@@ -15,7 +15,6 @@
 #include "bps.h"
 #include "gpio.h"
 
-
 /*
  * function prototypes
  */


### PR DESCRIPTION
### Changes

- We aren't quite ready for MISRA C checking yet.
- Just using regular cppcheck for now.
- MISRA linter configuration exists separately.
- Fixed some misc linter issues that had slipped through.

### Checklist

- [x] N/A ~~Code has been tested on STM32 hardware.~~
- [x] Changes do not generate any new compiler warnings.
- [x] Code has been formatted using `trunk fmt`.
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.

