### PR TITLE
feat(can): broadcast APPS and BPS readings

### DIFF
--- a/src/SUFST/Inc/CAN/canbc.h
+++ b/src/SUFST/Inc/CAN/canbc.h
@@ -25,6 +25,7 @@
 #define CANBC_ERROR_NONE        0x00000000U // no error
 #define CANBC_ERROR_INIT        0x00000001U // failed to initialise
 #define CANBC_ERROR_MEMORY_FULL 0x00000002U // not enough memory to create
+#define CANBC_ERROR_ARG         0x00000004U // invalid argument
 #define CANBC_ERROR_INTERNAL    0x80000000U // internal error
 
 /*
@@ -134,6 +135,16 @@ typedef struct _canbc_handle_t
     TX_THREAD thread;
 
     /**
+     * @brief   Broadcast tick timer
+     */
+    TX_TIMER tick_timer;
+
+    /**
+     * @brief   Broadcast period in ticks
+     */
+    uint32_t tick_period;
+
+    /**
      * @brief   RTCAN service to use for broadcasting
      */
     rtcan_handle_t* rtcan_h;
@@ -176,6 +187,7 @@ typedef struct _canbc_handle_t
 canbc_status_t canbc_init(canbc_handle_t* canbc_h,
                           rtcan_handle_t* rtcan_h,
                           UINT priority,
+                          uint32_t broadcast_period,
                           TX_BYTE_POOL* stack_pool_ptr);
 
 canbc_status_t canbc_start(canbc_handle_t* canbc_h);

--- a/src/SUFST/Inc/CAN/canbc.h
+++ b/src/SUFST/Inc/CAN/canbc.h
@@ -22,11 +22,12 @@
 /*
  * error codes
  */
-#define CANBC_ERROR_NONE        0x00000000U // no error
-#define CANBC_ERROR_INIT        0x00000001U // failed to initialise
-#define CANBC_ERROR_MEMORY_FULL 0x00000002U // not enough memory to create
-#define CANBC_ERROR_ARG         0x00000004U // invalid argument
-#define CANBC_ERROR_INTERNAL    0x80000000U // internal error
+#define CANBC_ERROR_NONE         0x00000000U // no error
+#define CANBC_ERROR_INIT         0x00000001U // failed to initialise
+#define CANBC_ERROR_MEMORY_FULL  0x00000002U // not enough memory to create
+#define CANBC_ERROR_SEGMENT_FULL 0x00000004U // no memory left in segment
+#define CANBC_ERROR_ARG          0x00000010U // invalid argument
+#define CANBC_ERROR_INTERNAL     0x80000000U // internal error
 
 /*
  * CAN broadcast status
@@ -97,7 +98,8 @@ typedef struct _canbc_segment_t
     /**
      * @brief   Pointer to mutex to be locked when reading data
      *
-     * @details NULL pointer will not be locked
+     * @details NULL pointer will not be locked.
+     *          Enabling priority inheritance on this mutex is a good idea.
      */
     TX_MUTEX* mutex_ptr;
 
@@ -114,12 +116,12 @@ typedef struct _canbc_segment_t
  * TODO: what happens if these sizes are truncated due to sizeof broadcast
  *       channel not being a multiple of sizeof(ULONG)
  */
-#define CANBC_CHANNEL_POOL_BLOCK_SIZE (sizeof(canbc_channel_t) / sizeof(ULONG))
+#define CANBC_CHANNEL_POOL_BLOCK_SIZE (sizeof(canbc_channel_t))
 
 #define CANBC_CHANNEL_POOL_SIZE \
     (CANBC_CHANNEL_POOL_BLOCK_SIZE * CANBC_MAX_NUM_CHANNELS)
 
-#define CANBC_SEGMENT_POOL_BLOCK_SIZE (sizeof(canbc_segment_t) / sizeof(ULONG))
+#define CANBC_SEGMENT_POOL_BLOCK_SIZE (sizeof(canbc_segment_t))
 
 #define CANBC_SEGMENT_POOL_SIZE \
     (CANBC_SEGMENT_POOL_BLOCK_SIZE * CANBC_MAX_NUM_SEGMENTS)

--- a/src/SUFST/Inc/config.h
+++ b/src/SUFST/Inc/config.h
@@ -70,6 +70,8 @@
 #define INVERTER_EEPROM_MAX_RETRY		        10		// maximum number of retry attempts
 #define INVERTER_EEPROM_RETRY_DELAY		        100		// in ms
 
+#define CANBC_DRIVER_INPUTS_ID                  0x100   // CAN broadcast address for driver inputs
+
 /***************************************************************************
  * sensors
  ***************************************************************************/

--- a/src/SUFST/Inc/config.h
+++ b/src/SUFST/Inc/config.h
@@ -56,6 +56,7 @@
        // enable TraceX logging
 
 #define DRIVER_CTRL_TICK_RATE               100 // times per second
+#define CANBC_BROADCAST_PERIOD              50 // milliseconds
 
 /***************************************************************************
  * CAN / inverter

--- a/src/SUFST/Inc/driver_control.h
+++ b/src/SUFST/Inc/driver_control.h
@@ -11,6 +11,7 @@
 
 #include "tx_api.h"
 
+#include "canbc.h"
 #include "ts_control.h"
 
 /*
@@ -47,13 +48,14 @@ typedef struct
     ts_ctrl_handle_t* ts_ctrl_h;
 
     /**
+     * @brief   State mutex for CAN broadcast
+     */
+    TX_MUTEX state_mutex;
+
+    /**
      * @brief   Driver inputs state
      */
-    struct
-    {
-        uint32_t accel_pressure;
-        uint32_t brake_pressure;
-    } inputs;
+    ts_ctrl_input_t ts_inputs;
 
     /**
      * @brief   Current error code
@@ -76,6 +78,7 @@ typedef enum
  */
 driver_ctrl_status_t driver_ctrl_init(driver_ctrl_handle_t* driver_ctrl_h,
                                       ts_ctrl_handle_t* ts_ctrl_h,
+                                      canbc_handle_t* canbc_h,
                                       TX_BYTE_POOL* stack_pool_ptr);
 
 driver_ctrl_status_t driver_ctrl_start(driver_ctrl_handle_t* driver_ctrl_h);

--- a/src/SUFST/Src/CAN/canbc.c
+++ b/src/SUFST/Src/CAN/canbc.c
@@ -60,7 +60,7 @@ canbc_status_t canbc_init(canbc_handle_t* canbc_h,
     }
 
     // memory pool for channels
-    UINT tx_status = TX_SUCCESS;
+    UINT tx_status;
 
     if (no_errors(canbc_h))
     {

--- a/src/SUFST/Src/CAN/canbc.c
+++ b/src/SUFST/Src/CAN/canbc.c
@@ -14,9 +14,10 @@
  * thread and pool constants
  */
 #define CANBC_THREAD_NAME       "CAN Broadcast Thread"
-#define CANBC_THREAD_STACK_SIZE 512 // TODO: this needs to be profiled
+#define CANBC_THREAD_STACK_SIZE 1024 // TODO: this needs to be profiled
 #define CANBC_CHANNEL_POOL_NAME "CAN Broadcast Channel Pool"
 #define CANBC_SEGMENT_POOL_NAME "CAN Broadcast Segment Pool"
+#define CANBC_TICK_TIMER_NAME   "CAN Broadcast Tick Timer"
 
 /*
  * internal functions
@@ -27,34 +28,51 @@ static void create_message(canbc_segment_t* segment_ptr, rtcan_msg_t* msg_ptr);
 
 static bool no_errors(canbc_handle_t* canbc_h);
 
+static void canbc_tick_callback(ULONG input);
+
 static void canbc_thread_entry(ULONG input);
 
 /**
  * @brief       Initialises the CAN broadcast service
  *
- * @param[in]   canbc_h     CAN broadcast handle
- * @param[in]   rtcan_h         RTCAN service handle for broadcasting data
- * @param[in]   priority        Service thread priority
- * @param[in]   stack_pool_ptr  Memory pool to allocate stack memory from
+ * @param[in]   canbc_h             CAN broadcast handle
+ * @param[in]   rtcan_h             RTCAN service handle for broadcasting data
+ * @param[in]   priority            Service thread priority
+ * @param[in]   broadcast_period    Broadcast period in milliseconds
+ * @param[in]   stack_pool_ptr      Memory pool to allocate stack memory from
  */
 canbc_status_t canbc_init(canbc_handle_t* canbc_h,
                           rtcan_handle_t* rtcan_h,
                           UINT priority,
+                          uint32_t broadcast_period,
                           TX_BYTE_POOL* stack_pool_ptr)
 {
     canbc_h->rtcan_h = rtcan_h;
     canbc_h->first_segment_ptr = NULL;
 
-    // memory pool for channels
-    UINT tx_status = tx_block_pool_create(&canbc_h->channel_pool,
-                                          CANBC_CHANNEL_POOL_NAME,
-                                          CANBC_CHANNEL_POOL_BLOCK_SIZE,
-                                          canbc_h->channel_pool_mem,
-                                          CANBC_CHANNEL_POOL_SIZE);
+    // timer tick period in ticks
+    canbc_h->tick_period
+        = (broadcast_period * TX_TIMER_TICKS_PER_SECOND) / 1000;
 
-    if (tx_status != TX_SUCCESS)
+    if (canbc_h->tick_period == 0)
     {
-        canbc_h->err |= CANBC_ERROR_INIT;
+        canbc_h->err |= CANBC_ERROR_ARG; // too fast!
+    }
+
+    // memory pool for channels
+    UINT tx_status = TX_SUCCESS;
+
+    if (no_errors(canbc_h))
+    {
+        tx_status = tx_block_pool_create(&canbc_h->channel_pool,
+                                         CANBC_CHANNEL_POOL_NAME,
+                                         CANBC_CHANNEL_POOL_BLOCK_SIZE,
+                                         canbc_h->channel_pool_mem,
+                                         CANBC_CHANNEL_POOL_SIZE);
+        if (tx_status != TX_SUCCESS)
+        {
+            canbc_h->err |= CANBC_ERROR_INIT;
+        }
     }
 
     // memory pool for segments
@@ -107,6 +125,23 @@ canbc_status_t canbc_init(canbc_handle_t* canbc_h,
         }
     }
 
+    // tick timer
+    if (no_errors(canbc_h))
+    {
+        tx_status = tx_timer_create(&canbc_h->tick_timer,
+                                    CANBC_TICK_TIMER_NAME,
+                                    canbc_tick_callback,
+                                    (ULONG) canbc_h,
+                                    canbc_h->tick_period,
+                                    canbc_h->tick_period,
+                                    TX_NO_ACTIVATE);
+
+        if (tx_status != TX_SUCCESS)
+        {
+            canbc_h->err |= CANBC_ERROR_INIT;
+        }
+    }
+
     return create_status(canbc_h);
 }
 
@@ -117,11 +152,24 @@ canbc_status_t canbc_init(canbc_handle_t* canbc_h,
  */
 canbc_status_t canbc_start(canbc_handle_t* canbc_h)
 {
-    UINT tx_status = tx_thread_resume(&canbc_h->thread);
-
-    if (tx_status != TX_SUCCESS)
+    if (no_errors(canbc_h))
     {
-        canbc_h->err |= CANBC_ERROR_INIT;
+        UINT tx_status = tx_thread_resume(&canbc_h->thread);
+
+        if (tx_status != TX_SUCCESS)
+        {
+            canbc_h->err |= CANBC_ERROR_INIT;
+        }
+    }
+
+    if (no_errors(canbc_h))
+    {
+        UINT tx_status = tx_timer_activate(&canbc_h->tick_timer);
+
+        if (tx_status != TX_SUCCESS)
+        {
+            canbc_h->err |= CANBC_ERROR_INIT;
+        }
     }
 
     return create_status(canbc_h);
@@ -250,6 +298,26 @@ uint32_t canbc_get_error(canbc_handle_t* canbc_h)
 {
     return canbc_h->err;
 }
+/**
+ * @brief       Tick timer callback
+ *
+ * @param[in]   input   CANBC handle
+ */
+static void canbc_tick_callback(ULONG input)
+{
+    canbc_handle_t* canbc_h = (canbc_handle_t*) input;
+
+    // restart thread
+    if (no_errors(canbc_h))
+    {
+        UINT status = tx_thread_resume(&canbc_h->thread);
+
+        if (status != TX_SUCCESS)
+        {
+            canbc_h->err |= CANBC_ERROR_INTERNAL;
+        }
+    }
+}
 
 /**
  * @brief       Entry function for CAN broadcast service thread
@@ -260,22 +328,25 @@ static void canbc_thread_entry(ULONG input)
 {
     canbc_handle_t* canbc_h = (canbc_handle_t*) input;
 
-    // TODO: tick to wake thread
-    // while (1)
-    // {
-    //     canbc_segment_t* segment_ptr = canbc_h->first_segment_ptr;
+    while (1)
+    {
+        // send off each channel for transmission
+        canbc_segment_t* segment_ptr = canbc_h->first_segment_ptr;
 
-    //     while (segment_ptr != NULL)
-    //     {
-    //         rtcan_msg_t message;
-    //         create_message(segment_ptr, &message);
+        while (segment_ptr != NULL)
+        {
+            rtcan_msg_t message;
+            create_message(segment_ptr, &message);
 
-    //         rtcan_transmit(canbc_h->rtcan_h, &message);
+            rtcan_transmit(canbc_h->rtcan_h, &message);
 
-    //         segment_ptr = segment_ptr->next_segment_ptr;
-    //     }
+            segment_ptr = segment_ptr->next_segment_ptr;
+        }
 
-    // }
+        // suspend until resumed by next tick
+        // TODO: handle error
+        (void) tx_thread_suspend(&canbc_h->thread);
+    }
 }
 
 /**

--- a/src/SUFST/Src/driver_control.c
+++ b/src/SUFST/Src/driver_control.c
@@ -21,6 +21,7 @@
 #define DRIVER_CTRL_THREAD_STACK_SIZE 1024
 #define DRIVER_CTRL_THREAD_NAME       "Driver Control Thread"
 #define DRIVER_CTRL_TIMER_NAME        "Driver Control Tick Timer"
+#define DRIVER_CTRL_STATE_MUTEX_NAME  "Driver Control State Mutex"
 
 /*
  * internal functions
@@ -35,13 +36,18 @@ static driver_ctrl_status_t create_status(driver_ctrl_handle_t* driver_ctrl_h);
  *
  * @param[in]   driver_ctrl_h   Driver control handle
  * @param[in]   ts_ctrl_h       TS controller handle
+ * @param[in]   canbc_h         CANBC service handle
  * @param[in]   stack_pool_ptr  Memory pool to allocate stack memory from
  */
 driver_ctrl_status_t driver_ctrl_init(driver_ctrl_handle_t* driver_ctrl_h,
                                       ts_ctrl_handle_t* ts_ctrl_h,
+                                      canbc_handle_t* canbc_h,
                                       TX_BYTE_POOL* stack_pool_ptr)
 {
     driver_ctrl_h->ts_ctrl_h = ts_ctrl_h;
+
+    driver_ctrl_h->ts_inputs.accel_pressure = 0;
+    driver_ctrl_h->ts_inputs.brake_pressure = 0;
 
     // thread
     {
@@ -67,6 +73,58 @@ driver_ctrl_status_t driver_ctrl_init(driver_ctrl_handle_t* driver_ctrl_h,
         }
 
         if (status != TX_SUCCESS)
+        {
+            driver_ctrl_h->err |= DRIVER_CTRL_ERROR_INIT;
+        }
+    }
+
+    // can broadcast service
+    if (no_errors(driver_ctrl_h))
+    {
+        UINT status = tx_mutex_create(&driver_ctrl_h->state_mutex,
+                                      DRIVER_CTRL_STATE_MUTEX_NAME,
+                                      TX_INHERIT);
+
+        if (status != TX_SUCCESS)
+        {
+            driver_ctrl_h->err |= DRIVER_CTRL_ERROR_INIT;
+        }
+    }
+
+    if (no_errors(driver_ctrl_h))
+    {
+        canbc_segment_t* segment_ptr;
+        canbc_status_t status
+            = canbc_create_segment(canbc_h,
+                                   &segment_ptr,
+                                   CANBC_DRIVER_INPUTS_ID,
+                                   &driver_ctrl_h->state_mutex);
+
+        if (status == CANBC_OK)
+        {
+            // TODO: channel_ptr unused, change CANBC to ignore parameter if
+            //       NULL
+            canbc_channel_t* channel_ptr;
+            status = canbc_create_channel(
+                canbc_h,
+                &channel_ptr,
+                segment_ptr,
+                (uint8_t*) &driver_ctrl_h->ts_inputs.accel_pressure,
+                sizeof(driver_ctrl_h->ts_inputs.accel_pressure));
+        }
+
+        if (status == CANBC_OK)
+        {
+            canbc_channel_t* channel_ptr;
+            status = canbc_create_channel(
+                canbc_h,
+                &channel_ptr,
+                segment_ptr,
+                (uint8_t*) &driver_ctrl_h->ts_inputs.brake_pressure,
+                sizeof(driver_ctrl_h->ts_inputs.brake_pressure));
+        }
+
+        if (status != CANBC_OK)
         {
             driver_ctrl_h->err |= DRIVER_CTRL_ERROR_INIT;
         }
@@ -135,22 +193,26 @@ static void driver_ctrl_thread_entry(ULONG input)
         while (1)
         {
             // read inputs
-            ts_ctrl_input_t inputs;
+            // TODO: handle error return
+            tx_mutex_get(&driver_ctrl_h->state_mutex, TX_WAIT_FOREVER);
 
 #if RUN_APPS_TESTBENCH
-            inputs.accel_pressure = testbench_apps_input();
+            driver_ctrl_h->ts_inputs.accel_pressure = testbench_apps_input();
 #else
-            inputs.accel_pressure = (ULONG) apps_read();
+            driver_ctrl_h->ts_inputs.accel_pressure = (ULONG) apps_read();
 #endif
 
-            inputs.brake_pressure = bps_read();
+            driver_ctrl_h->ts_inputs.brake_pressure = bps_read();
 
             // send inputs to TS controller
-            if (ts_ctrl_input_send(driver_ctrl_h->ts_ctrl_h, &inputs)
+            if (ts_ctrl_input_send(driver_ctrl_h->ts_ctrl_h,
+                                   &driver_ctrl_h->ts_inputs)
                 != TS_CTRL_OK)
             {
                 // TODO: handle error?
             }
+
+            tx_mutex_put(&driver_ctrl_h->state_mutex);
 
             // sleep thread to allow other threads to run
             // TODO: should the timer activation happen in the timer callback??

--- a/src/SUFST/Src/vcu.c
+++ b/src/SUFST/Src/vcu.c
@@ -122,6 +122,7 @@ vcu_status_t vcu_init(vcu_handle_t* vcu_h,
     {
         driver_ctrl_status_t status = driver_ctrl_init(&vcu_h->driver_ctrl,
                                                        &vcu_h->ts_ctrl,
+                                                       &vcu_h->canbc,
                                                        app_mem_pool);
 
         if (status != DRIVER_CTRL_OK)

--- a/src/SUFST/Src/vcu.c
+++ b/src/SUFST/Src/vcu.c
@@ -62,6 +62,7 @@ vcu_status_t vcu_init(vcu_handle_t* vcu_h,
         canbc_status_t status = canbc_init(&vcu_h->canbc,
                                            &vcu_h->rtcan_s,
                                            CANBC_PRIORITY,
+                                           CANBC_BROADCAST_PERIOD,
                                            app_mem_pool);
 
         if (status == CANBC_OK)


### PR DESCRIPTION
### Changes

- APPS and BPS readings broadcast to CAN S bus using RTCAN service.
- This can be monitored by the L120 datalogger, the config has been updated to do so.
- Fixes an issue with the block item size in the RTCAN service.

### Fixed Issue(s)

Closes #174 

### Checklist

- [x] Code has been tested on STM32 hardware.
- [x] Changes do not generate any new compiler warnings.
- [x] Code has been formatted using `trunk fmt`.
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.
