### PR TITLE
chore(vscode): set up Windows configurations

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,7 +1,7 @@
 {
   "configurations": [
     {
-      "name": "arm-none-eabi-gcc",
+      "name": "MAC-arm-none-eabi-gcc",
       "compileCommands": "${workspaceFolder}/compile_commands.json",
       "includePath": [
         "${workspaceFolder}/src/SUFST/Inc",
@@ -18,6 +18,29 @@
         "USE_HAL_DRIVER",
         "STM32H723xx"
       ],
+      "cStandard": "gnu11",
+      "intelliSenseMode": "gcc-arm",
+      "configurationProvider": "ms-vscode.makefile-tools"
+    },
+    {
+      "name": "WIN-arm-none-eabi-gcc",
+      "includePath": [
+        "${workspaceFolder}/**",
+        "${workspaceFolder}/src/SUFST/Inc",
+        "${workspaceFolder}/src/Core/Inc",
+        "${workspaceFolder}/src/Drivers/STM32F7xx_HAL_Driver/Inc",
+        "${workspaceFolder}/src/Drivers/CMSIS/Device/ST/STM32F7xx/Include",
+        "${workspaceFolder}/src/Drivers/CMSIS/Include",
+        "${workspaceFolder}/src/Middlewares/ST/threadx/common/inc",
+        "${workspaceFolder}/src/Middlewares/ST/threadx/ports/cortex_m7/gnu/inc",
+        "${workspaceFolder}/src/SUFST/Inc/CAN"
+      ],
+      "defines": [
+        "TX_INCLUDE_USER_DEFINE_FILE",
+        "USE_HAL_DRIVER",
+        "STM32H723xx"
+      ],
+      "compilerPath": "C:/Program Files (x86)/GNU Arm Embedded Toolchain/10 2021.10/bin/arm-none-eabi-gcc.exe",
       "cStandard": "gnu11",
       "intelliSenseMode": "gcc-arm",
       "configurationProvider": "ms-vscode.makefile-tools"

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -25,7 +25,7 @@
         },
         {
             "name": "WIN-arm-none-eabi-gcc",
-            "compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
+            "compileCommands": "${workspaceFolder}/compile_commands.json",
             "includePath": [
                 "${workspaceFolder}/**",
                 "${workspaceFolder}/src/Drivers/**"

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -25,6 +25,7 @@
         },
         {
             "name": "WIN-arm-none-eabi-gcc",
+            "compileCommands": "${workspaceFolder}/.vscode/compile_commands.json",
             "includePath": [
                 "${workspaceFolder}/**",
                 "${workspaceFolder}/src/Drivers/**"

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,55 +1,45 @@
 {
-  "configurations": [
-    {
-      "name": "MAC-arm-none-eabi-gcc",
-      "compileCommands": "${workspaceFolder}/compile_commands.json",
-      "includePath": [
-        "${workspaceFolder}/src/SUFST/Inc",
-        "${workspaceFolder}/src/Core/Inc",
-        "${workspaceFolder}/src/Drivers/STM32F7xx_HAL_Driver/Inc",
-        "${workspaceFolder}/src/Drivers/CMSIS/Device/ST/STM32F7xx/Include",
-        "${workspaceFolder}/src/Drivers/CMSIS/**",
-        "${workspaceFolder}/src/Middlewares/ST/threadx/common/inc",
-        "${workspaceFolder}/src/Middlewares/ST/threadx/ports/cortex_m7/gnu/inc",
-        "${workspaceFolder}/src/SUFST/Inc/CAN",
-        "${workspaceFolder}/src/Drivers/STM32F7xx_HAL_Driver/Inc"
-      ],
-      "defines": [
-        "TX_INCLUDE_USER_DEFINE_FILE",
-        "USE_HAL_DRIVER",
-        "STM32H723xx"
-      ],
-      "cStandard": "gnu11",
-      "intelliSenseMode": "gcc-arm",
-      "configurationProvider": "ms-vscode.makefile-tools"
-    },
-    {
-      "name": "WIN-arm-none-eabi-gcc",
-      "includePath": [
-        "${workspaceFolder}/**",
-        "${workspaceFolder}/src/SUFST/Inc",
-        "${workspaceFolder}/src/Core/Inc",
-        "${workspaceFolder}/src/Drivers/STM32F7xx_HAL_Driver/Inc",
-        "${workspaceFolder}/src/Drivers/CMSIS/Device/ST/STM32F7xx/Include",
-        "${workspaceFolder}/src/Drivers/CMSIS/Include",
-        "${workspaceFolder}/src/Drivers/CMSIS/**",
-        "${workspaceFolder}/src/Middlewares/**",
-        "${workspaceFolder}/src/SUFST/Inc/CAN",
-        "${workspaceFolder}/src/Drivers/STM32F7xx_HAL_Driver/Inc",
-        "${workspaceFolder}/src/Drivers/**",
-        "${workspaceFolder}/src/Drivers/CMSIS/Device/ST/STM32F7xx/Include",
-        "${workspaceFolder}/src/AZURE_RTOS/**"
-      ],
-      "defines": [
-        "TX_INCLUDE_USER_DEFINE_FILE",
-        "USE_HAL_DRIVER",
-        "STM32H723xx"
-      ],
-      "compilerPath": "C:/Program Files (x86)/GNU Arm Embedded Toolchain/10 2021.10/bin/arm-none-eabi-gcc.exe",
-      "cStandard": "gnu11",
-      "intelliSenseMode": "gcc-arm",
-      "configurationProvider": "ms-vscode.makefile-tools"
-    }
-  ],
-  "version": 4
+    "configurations": [
+        {
+            "name": "MAC-arm-none-eabi-gcc",
+            "compileCommands": "${workspaceFolder}/compile_commands.json",
+            "includePath": [
+                "${workspaceFolder}/src/SUFST/Inc",
+                "${workspaceFolder}/src/Core/Inc",
+                "${workspaceFolder}/src/Drivers/STM32F7xx_HAL_Driver/Inc",
+                "${workspaceFolder}/src/Drivers/CMSIS/Device/ST/STM32F7xx/Include",
+                "${workspaceFolder}/src/Drivers/CMSIS/**",
+                "${workspaceFolder}/src/Middlewares/ST/threadx/common/inc",
+                "${workspaceFolder}/src/Middlewares/ST/threadx/ports/cortex_m7/gnu/inc",
+                "${workspaceFolder}/src/SUFST/Inc/CAN",
+                "${workspaceFolder}/src/Drivers/STM32F7xx_HAL_Driver/Inc"
+            ],
+            "defines": [
+                "TX_INCLUDE_USER_DEFINE_FILE",
+                "USE_HAL_DRIVER",
+                "STM32H723xx"
+            ],
+            "cStandard": "gnu11",
+            "intelliSenseMode": "gcc-arm",
+            "configurationProvider": "ms-vscode.makefile-tools"
+        },
+        {
+            "name": "WIN-arm-none-eabi-gcc",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "${workspaceFolder}/src/Drivers/**"
+            ],
+            "defines": [
+                "TX_INCLUDE_USER_DEFINE_FILE",
+                "USE_HAL_DRIVER",
+                "STM32H723xx",
+                "__CC_ARM"
+            ],
+            "compilerPath": "C:/Program Files (x86)/GNU Arm Embedded Toolchain/10 2021.10/bin/arm-none-eabi-gcc.exe",
+            "cStandard": "gnu11",
+            "intelliSenseMode": "gcc-arm",
+            "configurationProvider": "ms-vscode.makefile-tools"
+        }
+    ],
+    "version": 4
 }

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -8,10 +8,11 @@
         "${workspaceFolder}/src/Core/Inc",
         "${workspaceFolder}/src/Drivers/STM32F7xx_HAL_Driver/Inc",
         "${workspaceFolder}/src/Drivers/CMSIS/Device/ST/STM32F7xx/Include",
-        "${workspaceFolder}/src/Drivers/CMSIS/Include",
+        "${workspaceFolder}/src/Drivers/CMSIS/**",
         "${workspaceFolder}/src/Middlewares/ST/threadx/common/inc",
         "${workspaceFolder}/src/Middlewares/ST/threadx/ports/cortex_m7/gnu/inc",
-        "${workspaceFolder}/src/SUFST/Inc/CAN"
+        "${workspaceFolder}/src/SUFST/Inc/CAN",
+        "${workspaceFolder}/src/Drivers/STM32F7xx_HAL_Driver/Inc"
       ],
       "defines": [
         "TX_INCLUDE_USER_DEFINE_FILE",
@@ -31,9 +32,13 @@
         "${workspaceFolder}/src/Drivers/STM32F7xx_HAL_Driver/Inc",
         "${workspaceFolder}/src/Drivers/CMSIS/Device/ST/STM32F7xx/Include",
         "${workspaceFolder}/src/Drivers/CMSIS/Include",
-        "${workspaceFolder}/src/Middlewares/ST/threadx/common/inc",
-        "${workspaceFolder}/src/Middlewares/ST/threadx/ports/cortex_m7/gnu/inc",
-        "${workspaceFolder}/src/SUFST/Inc/CAN"
+        "${workspaceFolder}/src/Drivers/CMSIS/**",
+        "${workspaceFolder}/src/Middlewares/**",
+        "${workspaceFolder}/src/SUFST/Inc/CAN",
+        "${workspaceFolder}/src/Drivers/STM32F7xx_HAL_Driver/Inc",
+        "${workspaceFolder}/src/Drivers/**",
+        "${workspaceFolder}/src/Drivers/CMSIS/Device/ST/STM32F7xx/Include",
+        "${workspaceFolder}/src/AZURE_RTOS/**"
       ],
       "defines": [
         "TX_INCLUDE_USER_DEFINE_FILE",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,7 +36,8 @@
     "stdint.h": "c",
     "apps.h": "c",
     "limits": "c",
-    "ready_to_drive.h": "c"
+    "ready_to_drive.h": "c",
+    "stm32f7xx_hal_def.h": "c"
   },
   "cortex-debug.variableUseNaturalFormat": false
 }


### PR DESCRIPTION
### Changes

- Created new vscode configuration for windows named `WIN-arm-none-eabi-gcc`. New windows users will need to run ccdgen and save the `compile_commands.json` file to `${workspaceFolder}/compile_commands.json`. I can add some documentation for this.
- Mac configuration changed to `MAC-arm-none-eabi-gcc`.

### Fixed Issue(s)

Closes #182 

### Checklist

- [x] N/A ~~Code has been tested on STM32 hardware.~~
- [x] N/A ~~Changes do not generate any new compiler warnings.~~
- [x] N/A ~~Code has been formatted using `trunk fmt`.~~
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.

### Additional Notes

None
