### PR TITLE
build: fix issue with makefile dry runs for `ccdgen`

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -35,6 +35,16 @@
       "args": ["flash", "-s", "-j $(nproc)"],
       "group": "build"
     },
+    // generate compile commands
+    {
+      "label": "ccdgen",
+      "type": "shell",
+      "command": "python",
+      "osx": {
+        "command": "python3"
+      },
+      "args": ["-m", "ccdgen", "--extensions", ".c", "--", "make", "-j"]
+    },
     // open STM32CubeMX
     {
       "label": "STM32CubeMX",

--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ vpath %.s $(sort $(dir $(ASM_SOURCES)))
 
 # default build all
 all: 
-	make $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin \
+	$(MAKE) $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin
 
 # pre build
 .PHONY: prebuild


### PR DESCRIPTION
### Changes

- Fixes incorrect call to `make` instead of `$(MAKE)` which prevents `--dry-run` from printing commands and breaks `ccdgen`.
- Adds a VS Code task for `ccdgen`.

### Checklist

- [x] N/A ~~Code has been tested on STM32 hardware.~~
- [x] N/A ~~Changes do not generate any new compiler warnings.~~
- [x] Code has been formatted using `trunk fmt`.
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.

