### PR TITLE
style: tidy up `#include` ordering

### DIFF
--- a/.trunk/config/.clang-format
+++ b/.trunk/config/.clang-format
@@ -62,19 +62,15 @@ BraceWrapping:
 IncludeBlocks: Regroup
 SortIncludes: CaseSensitive
 IncludeCategories:
-    -   Regex: '^<(std)([A-Za-z0-9.\/-_])+>'
+    # -   Regex: '^<(std)([A-Za-z0-9.\/-_])+>'
+    #     Priority: 2
+    #     SortPriority: 2
+    #     CaseSensitive: true
+    -   Regex: '^<([A-Za-z0-9.\/-_])+>'
         Priority: 1
         SortPriority: 1
         CaseSensitive: true
-    -   Regex: '^"(tx_api|config)([A-Za-z0-9.\/-_])+"'
+    -   Regex: '^"([A-Za-z0-9.\/-_])+"'
         Priority: 2
         SortPriority: 2
-        CaseSensitive: true
-    -   Regex: '^"(testbench|trace|fault)([A-Za-z0-9.\/-_])+"'
-        Priority: 3
-        SortPriority: 3
-        CaseSensitive: true
-    -   Regex: '^"(adc|dac|fdcan|gpio|rtc|scs|apps|rtd|bps)([A-Za-z0-9.\/-_])+"'
-        Priority: 4
-        SortPriority: 4
         CaseSensitive: true

--- a/src/SUFST/Inc/CAN/canbc.h
+++ b/src/SUFST/Inc/CAN/canbc.h
@@ -8,9 +8,8 @@
 #ifndef CANBC_H
 #define CANBC_H
 
-#include "tx_api.h"
-
 #include "rtcan.h"
+#include "tx_api.h"
 
 /*
  * channel and segment constants

--- a/src/SUFST/Inc/CAN/pm100.h
+++ b/src/SUFST/Inc/CAN/pm100.h
@@ -10,9 +10,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "rtcan.h"
-
 #include "can_database.h"
+#include "rtcan.h"
 #include "status.h"
 
 #define PM100_ERROR_NONE          0x00000000U // no error

--- a/src/SUFST/Inc/Tasks/driver_control.h
+++ b/src/SUFST/Inc/Tasks/driver_control.h
@@ -9,10 +9,9 @@
 
 #include <stdint.h>
 
-#include "tx_api.h"
-
 #include "canbc.h"
 #include "ts_control.h"
+#include "tx_api.h"
 
 /*
  * error codes

--- a/src/SUFST/Inc/Tasks/ts_control.h
+++ b/src/SUFST/Inc/Tasks/ts_control.h
@@ -9,11 +9,9 @@
 
 #include <stdint.h>
 
-#include "tx_api.h"
-
-#include "rtcan.h"
-
 #include "pm100.h"
+#include "rtcan.h"
+#include "tx_api.h"
 
 /*
  * error codes

--- a/src/SUFST/Inc/Test/testbench.h
+++ b/src/SUFST/Inc/Test/testbench.h
@@ -8,9 +8,8 @@
 #ifndef TESTBENCH_H
 #define TESTBENCH_H
 
-#include "tx_api.h"
-
 #include "../config.h"
+#include "tx_api.h"
 
 /***************************************************************************
  * APPS input testbench

--- a/src/SUFST/Inc/ready_to_drive.h
+++ b/src/SUFST/Inc/ready_to_drive.h
@@ -7,13 +7,12 @@
 #ifndef READY_TO_DRIVE_H
 #define READY_TO_DRIVE_H
 
+#include <gpio.h>
 #include <stdatomic.h>
 #include <stdint.h>
+#include <tx_api.h>
 
 #include "bps.h"
-
-#include <gpio.h>
-#include <tx_api.h>
 
 /**
  * @brief   Ready to drive context

--- a/src/SUFST/Inc/vcu.h
+++ b/src/SUFST/Inc/vcu.h
@@ -8,15 +8,15 @@
 #ifndef VCU_H
 #define VCU_H
 
+#include <can.h>
+#include <rtcan.h>
 #include <stdint.h>
+#include <tx_api.h>
 
 #include "canbc.h"
 #include "driver_control.h"
 #include "ready_to_drive.h"
 #include "ts_control.h"
-#include <can.h>
-#include <rtcan.h>
-#include <tx_api.h>
 
 /*
  * error codes

--- a/src/SUFST/Src/Sensors/apps.c
+++ b/src/SUFST/Src/Sensors/apps.c
@@ -8,12 +8,10 @@
 
 #include <stdbool.h>
 
-#include "config.h"
-
-#include "trace.h"
-
 #include "adc.h"
+#include "config.h"
 #include "scs.h"
+#include "trace.h"
 
 /**
  * @brief Safety critical signal instances for APPS

--- a/src/SUFST/Src/Sensors/bps.c
+++ b/src/SUFST/Src/Sensors/bps.c
@@ -7,7 +7,6 @@
 #include "bps.h"
 
 #include "config.h"
-
 #include "scs.h"
 
 /**

--- a/src/SUFST/Src/Tasks/driver_control.c
+++ b/src/SUFST/Src/Tasks/driver_control.c
@@ -8,12 +8,10 @@
 
 #include <stdbool.h>
 
-#include "config.h"
-
+#include "Test/testbench.h"
 #include "apps.h"
 #include "bps.h"
-
-#include "Test/testbench.h"
+#include "config.h"
 
 /*
  * macro constants

--- a/src/SUFST/Src/Tasks/ts_control.c
+++ b/src/SUFST/Src/Tasks/ts_control.c
@@ -8,9 +8,8 @@
 
 #include <stdbool.h>
 
-#include "config.h"
-
 #include "can_database.h"
+#include "config.h"
 #include "driver_profiles.h"
 
 /*

--- a/src/SUFST/Src/Test/testbench.c
+++ b/src/SUFST/Src/Test/testbench.c
@@ -11,7 +11,6 @@
 
 #if RUN_FAULT_STATE_TESTBENCH
 #include "fault.h"
-
 #include "gpio.h"
 #endif
 

--- a/src/SUFST/Src/ready_to_drive.c
+++ b/src/SUFST/Src/ready_to_drive.c
@@ -9,11 +9,10 @@
 
 #include <stdbool.h>
 
-#include "config.h"
-#include "tx_api.h"
-
 #include "bps.h"
+#include "config.h"
 #include "gpio.h"
+#include "tx_api.h"
 
 static void start_speaker_sound(rtd_context_t* rtd_ptr);
 static void spkr_timer_expiry_callback(ULONG input);

--- a/src/SUFST/Src/shutdown.c
+++ b/src/SUFST/Src/shutdown.c
@@ -6,13 +6,11 @@
 
 #include "shutdown.h"
 
+#include <inttypes.h>
 #include <stdint.h>
 
-#include "tx_api.h"
-
 #include "gpio.h"
-
-#include <inttypes.h>
+#include "tx_api.h"
 
 // // ISR for all EXTI pin change interupts
 // void HAL_GPIO_EXTI_Callback(uint16_t GPIO_pin)

--- a/src/SUFST/Src/vcu.c
+++ b/src/SUFST/Src/vcu.c
@@ -8,11 +8,9 @@
 
 #include <stdbool.h>
 
-#include "config.h"
-
 #include "apps.h"
 #include "bps.h"
-
+#include "config.h"
 #include "ready_to_drive.h"
 
 /*


### PR DESCRIPTION
### Changes

- `#include`s now simply grouped by `<>` vs `""`

### Checklist

- [x] N/A ~~Code has been tested on STM32 hardware.~~
- [x] Changes do not generate any new compiler warnings.
- [x] Code has been formatted using `trunk fmt`.
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.
