### PR TITLE
feat: improved CAN broadcasting service

### DIFF
--- a/src/Core/Src/main.c
+++ b/src/Core/Src/main.c
@@ -209,6 +209,7 @@ void Error_Handler(void)
   __disable_irq();
   while (1)
   {
+    HAL_GPIO_WritePin(RED_LED_GPIO_Port, RED_LED_Pin, GPIO_PIN_SET);
   }
   /* USER CODE END Error_Handler_Debug */
 }

--- a/src/SUFST/Inc/CAN/canbc.h
+++ b/src/SUFST/Inc/CAN/canbc.h
@@ -23,10 +23,19 @@
  */
 typedef struct
 {
+    // driver inputs
     uint16_t apps_reading;
     uint16_t bps_reading;
     uint32_t torque_request;
-    uint32_t rolling_counter;
+
+    // VCU internal states
+    struct
+    {
+        uint8_t r2d : 1;
+        uint8_t shutdown : 1;
+        uint8_t UNUSED1 : 6;
+    } vcu_state;
+
 } canbc_states_t;
 
 /**
@@ -42,6 +51,7 @@ typedef struct
     uint32_t bc_period;
 
     canbc_states_t states;
+    uint16_t rolling_counter;
 
 } canbc_handle_t;
 

--- a/src/SUFST/Inc/CAN/canbc.h
+++ b/src/SUFST/Inc/CAN/canbc.h
@@ -8,202 +8,54 @@
 #ifndef CANBC_H
 #define CANBC_H
 
-#include "rtcan.h"
-#include "tx_api.h"
-
-/*
- * channel and segment constants
- */
-#define CANBC_MAX_NUM_CHANNELS  10
-#define CANBC_MAX_NUM_SEGMENTS  4
-#define CANBC_BYTES_PER_SEGMENT 8
-
-/*
- * error codes
- */
-#define CANBC_ERROR_NONE         0x00000000U // no error
-#define CANBC_ERROR_INIT         0x00000001U // failed to initialise
-#define CANBC_ERROR_MEMORY_FULL  0x00000002U // not enough memory to create
-#define CANBC_ERROR_SEGMENT_FULL 0x00000004U // no memory left in segment
-#define CANBC_ERROR_ARG          0x00000010U // invalid argument
-#define CANBC_ERROR_INTERNAL     0x80000000U // internal error
-
-/*
- * CAN broadcast status
- */
-typedef enum _canbc_status_t
-{
-    CANBC_OK,
-    CANBC_ERROR
-} canbc_status_t;
+#include <can.h>
+#include <rtcan.h>
+#include <stdint.h>
+#include <tx_api.h>
 
 /**
- * @brief   Broadcast channel
+ * @brief   Stores system states which will be broadcast to the CAN bus
  *
- * @details Represents a single datapoint which can be broadcast
+ * @details This is a COPY of specific module states which are useful to
+ *          monitor with the datalogger / telemetry systems. Modules are
+ *          responsible for updating the broadcast states when their
+ *          corresponding states change.
  */
-
-typedef struct _canbc_channel_t
+typedef struct
 {
-
-    /**
-     * @brief   Pointer to the data to be broadcast
-     *
-     * @details This must not go out of the scope while the channel is activated
-     */
-    uint8_t* data_ptr;
-
-    /**
-     * @brief   Length of data in bytes
-     */
-    uint32_t data_length;
-
-    /**
-     * @brief   Index of first data byte within segment
-     */
-    uint32_t byte_offset;
-
-    /**
-     * @brief   Link to next channel
-     */
-    struct _canbc_channel_t* next_channel_ptr;
-
-} canbc_channel_t;
+    uint16_t apps_reading;
+    uint16_t bps_reading;
+    uint32_t torque_request;
+    uint32_t rolling_counter;
+} canbc_states_t;
 
 /**
- * @brief   Broadcast segment
- *
- * @details Represents a set of channels which can be broadcast in a single
- *          CAN message. Channels are stored as a linked list.
+ * @brief   CAN broadcasting service context
  */
-typedef struct _canbc_segment_t
+typedef struct
 {
 
-    /**
-     * @brief   CAN standard ID for broadcast message containing segment
-     */
-    uint32_t identifier;
-
-    /**
-     * @brief   Channel count
-     */
-    uint32_t bytes_used;
-
-    /**
-     * @brief   First channel in the segment, linked to the next channel
-     */
-    canbc_channel_t* first_channel_ptr;
-
-    /**
-     * @brief   Pointer to mutex to be locked when reading data
-     *
-     * @details NULL pointer will not be locked.
-     *          Enabling priority inheritance on this mutex is a good idea.
-     */
-    TX_MUTEX* mutex_ptr;
-
-    /**
-     * @brief   Link to next segment
-     */
-    struct _canbc_segment_t* next_segment_ptr;
-
-} canbc_segment_t;
-
-/**
- * memory pool sizing constants
- *
- * TODO: what happens if these sizes are truncated due to sizeof broadcast
- *       channel not being a multiple of sizeof(ULONG)
- */
-#define CANBC_CHANNEL_POOL_BLOCK_SIZE (sizeof(canbc_channel_t))
-
-#define CANBC_CHANNEL_POOL_SIZE \
-    (CANBC_CHANNEL_POOL_BLOCK_SIZE * CANBC_MAX_NUM_CHANNELS)
-
-#define CANBC_SEGMENT_POOL_BLOCK_SIZE (sizeof(canbc_segment_t))
-
-#define CANBC_SEGMENT_POOL_SIZE \
-    (CANBC_SEGMENT_POOL_BLOCK_SIZE * CANBC_MAX_NUM_SEGMENTS)
-
-/**
- * @brief   CAN broadcaster
- */
-typedef struct _canbc_handle_t
-{
-    /**
-     * @brief   Broadcast service thread
-     */
     TX_THREAD thread;
+    TX_MUTEX state_mutex;
 
-    /**
-     * @brief   Broadcast tick timer
-     */
-    TX_TIMER tick_timer;
-
-    /**
-     * @brief   Broadcast period in ticks
-     */
-    uint32_t tick_period;
-
-    /**
-     * @brief   RTCAN service to use for broadcasting
-     */
     rtcan_handle_t* rtcan_h;
+    uint32_t bc_period;
 
-    /**
-     * @brief   Block pool for channels
-     */
-    TX_BLOCK_POOL channel_pool;
-
-    /**
-     * @brief   Memory for channels block pool
-     */
-    ULONG channel_pool_mem[CANBC_CHANNEL_POOL_SIZE];
-
-    /**
-     * @brief   Block pool for segments
-     */
-    TX_BLOCK_POOL segment_pool;
-
-    /**
-     * @brief   Memory for segments block pool
-     */
-    ULONG segment_pool_mem[CANBC_SEGMENT_POOL_SIZE];
-
-    /**
-     * @brief   First segment, linked to the next segment
-     */
-    canbc_segment_t* first_segment_ptr;
-
-    /**
-     * @brief   Current error code
-     */
-    uint32_t err;
+    canbc_states_t states;
 
 } canbc_handle_t;
 
 /*
- * function prototypes
+ * public functions
  */
-canbc_status_t canbc_init(canbc_handle_t* canbc_h,
-                          rtcan_handle_t* rtcan_h,
-                          UINT priority,
-                          uint32_t broadcast_period,
-                          TX_BYTE_POOL* stack_pool_ptr);
+void canbc_init(canbc_handle_t* canbc_h,
+                rtcan_handle_t* rtcan_h,
+                uint32_t period,
+                uint32_t priority,
+                TX_BYTE_POOL* stack_pool_ptr);
 
-canbc_status_t canbc_start(canbc_handle_t* canbc_h);
+canbc_states_t* canbc_lock_state(canbc_handle_t* canbc_h, uint32_t timeout);
 
-canbc_status_t canbc_create_segment(canbc_handle_t* canbc_h,
-                                    canbc_segment_t** segment_ptr,
-                                    uint32_t identifier,
-                                    TX_MUTEX* mutex_ptr);
-
-canbc_status_t canbc_create_channel(canbc_handle_t* canbc_h,
-                                    canbc_channel_t** channel_ptr,
-                                    canbc_segment_t* segment_ptr,
-                                    uint8_t* data_ptr,
-                                    uint32_t data_length);
-
-uint32_t canbc_get_error(canbc_handle_t* canbc_h);
+void canbc_unlock_state(canbc_handle_t* canbc_h);
 
 #endif

--- a/src/SUFST/Inc/CAN/pm100.h
+++ b/src/SUFST/Inc/CAN/pm100.h
@@ -57,7 +57,6 @@ typedef struct
  * function prototypes
  */
 status_t pm100_init(pm100_handle_t* pm100_h, rtcan_handle_t* rtcan_h);
-status_t pm100_enable(pm100_handle_t* pm100_h);
 status_t pm100_disable(pm100_handle_t* pm100_h);
 status_t pm100_request_torque(pm100_handle_t* pm100_h, uint32_t torque);
 status_t pm100_process_broadcast_msgs(pm100_handle_t* pm100_h);

--- a/src/SUFST/Inc/Sensors/scs.h
+++ b/src/SUFST/Inc/Sensors/scs.h
@@ -45,7 +45,7 @@ typedef struct
     /**
      * @brief Cached scale factor for mapping
      */
-    uint32_t scale_factor;
+    float scale_factor;
 
     /**
      * @brief Cached max bounds difference for validation

--- a/src/SUFST/Inc/Tasks/driver_control.h
+++ b/src/SUFST/Inc/Tasks/driver_control.h
@@ -8,10 +8,10 @@
 #define DRIVER_CONTROL_H
 
 #include <stdint.h>
+#include <tx_api.h>
 
 #include "canbc.h"
 #include "ts_control.h"
-#include "tx_api.h"
 
 /*
  * error codes
@@ -57,11 +57,16 @@ typedef struct
     ts_ctrl_input_t ts_inputs;
 
     /**
+     * @brief   CAN broadcaster instance
+     */
+    canbc_handle_t* canbc_h;
+
+    /**
      * @brief   Current error code
      */
     uint32_t err;
 
-} driver_ctrl_handle_t;
+} dc_handle_t;
 
 /**
  * @brief   Driver controls status
@@ -75,11 +80,11 @@ typedef enum
 /*
  * function prototypes
  */
-driver_ctrl_status_t driver_ctrl_init(driver_ctrl_handle_t* driver_ctrl_h,
+driver_ctrl_status_t driver_ctrl_init(dc_handle_t* dc_h,
                                       ts_ctrl_handle_t* ts_ctrl_h,
                                       canbc_handle_t* canbc_h,
                                       TX_BYTE_POOL* stack_pool_ptr);
 
-driver_ctrl_status_t driver_ctrl_start(driver_ctrl_handle_t* driver_ctrl_h);
+driver_ctrl_status_t driver_ctrl_start(dc_handle_t* dc_h);
 
 #endif

--- a/src/SUFST/Inc/config.h
+++ b/src/SUFST/Inc/config.h
@@ -71,8 +71,6 @@
 #define APPS_DISABLE_SCS_CHECK              1       // disable check for APPS ADC reading out of bounds
 
 #define APPS_ADC_RESOLUTION                 16      // resolution of raw APPS input from ADC
-#define APPS_SCALED_RESOLUTION              10      // scaled (truncated) APPS 
-
 #define APPS_MAX_DIFF_FRACTION              0.025f  // maximum allowable difference between APPS inputs as a fraction of scaled range
 #define APPS_OUTSIDE_BOUNDS_FRACTION        0.01f   // fraction of full ADC range above/below ADC min/max considered 'out of bounds'
 

--- a/src/SUFST/Inc/config.h
+++ b/src/SUFST/Inc/config.h
@@ -10,7 +10,7 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
-#include "tx_api.h"
+#include <tx_api.h>
 
 /***************************************************************************
  * competition mode 
@@ -51,7 +51,7 @@
 #define TRACEX_ENABLE                       0
        // enable TraceX logging
 
-#define DRIVER_CTRL_TICK_RATE               100  // times per second
+#define DRIVER_CTRL_TICK_RATE               100 // times per second
 #define CANBC_BROADCAST_PERIOD              100 // milliseconds
 
 /***************************************************************************
@@ -62,10 +62,6 @@
 
 #define INVERTER_SPEED_MODE                     0       // replace torque requests with speed requests
 #define INVERTER_TORQUE_REQUEST_TIMEOUT	        100		// in ms
-#define INVERTER_EEPROM_MAX_RETRY		        10		// maximum number of retry attempts
-#define INVERTER_EEPROM_RETRY_DELAY		        100		// in ms
-
-#define CANBC_DRIVER_INPUTS_ID                  0x100   // CAN broadcast address for driver inputs
 
 /***************************************************************************
  * sensors
@@ -80,10 +76,10 @@
 #define APPS_MAX_DIFF_FRACTION              0.025f  // maximum allowable difference between APPS inputs as a fraction of scaled range
 #define APPS_OUTSIDE_BOUNDS_FRACTION        0.01f   // fraction of full ADC range above/below ADC min/max considered 'out of bounds'
 
-#define APPS_1_ADC_MIN                      1540    //  minimum raw ADC reading for APPS  channel 1
-#define APPS_2_ADC_MIN                      1540    // ^                                ^ channel 2
-#define APPS_1_ADC_MAX                      2780    //  maximum raw ADC reading for APPS  channel 1
-#define APPS_2_ADC_MAX                      2780    // ^                                ^ channel 2
+#define APPS_1_ADC_MIN                      0x600    //  minimum raw ADC reading for APPS  channel 1
+#define APPS_2_ADC_MIN                      0x600    // ^                                ^ channel 2
+#define APPS_1_ADC_MAX                      0x900    //  maximum raw ADC reading for APPS  channel 1
+#define APPS_2_ADC_MAX                      0x900    // ^                                ^ channel 2
 
 /***************************************************************************
  * BPS - brake pressure sensor

--- a/src/SUFST/Inc/ready_to_drive.h
+++ b/src/SUFST/Inc/ready_to_drive.h
@@ -13,6 +13,7 @@
 #include <tx_api.h>
 
 #include "bps.h"
+#include "canbc.h"
 
 /**
  * @brief   Ready to drive context
@@ -22,6 +23,8 @@ typedef struct
     GPIO_TypeDef* spkr_gpio_port;
     uint32_t spkr_gpio_pin;
     bool enable_bps_check;
+
+    atomic_bool ready;
 
     TX_SEMAPHORE sem;
     TX_TIMER speaker_timer;
@@ -40,5 +43,7 @@ void rtd_init(rtd_context_t* rtd_ptr,
 void rtd_wait(rtd_context_t* rtd_ptr);
 
 void rtd_handle_int(rtd_context_t* rtd_ptr);
+
+bool rtd_is_ready(rtd_context_t* rtd_ptr);
 
 #endif

--- a/src/SUFST/Inc/vcu.h
+++ b/src/SUFST/Inc/vcu.h
@@ -63,7 +63,7 @@ typedef struct
     /**
      * @brief   Driver control input service
      */
-    driver_ctrl_handle_t driver_ctrl;
+    dc_handle_t driver_ctrl;
 
     /**
      * @brief   Initialisation thread

--- a/src/SUFST/Src/CAN/canbc.c
+++ b/src/SUFST/Src/CAN/canbc.c
@@ -6,107 +6,50 @@
 
 #include "canbc.h"
 
-#include <stdbool.h>
+#include "can_database.h"
 
-#include <memory.h>
+#define CANBC_THREAD_STACK_SIZE  1024
+#define CANBC_THREAD_NAME        "CANBC Thread"
+#define CANBC_STATE_MUTEX_NAME   "CANBC State Mutex"
+#define CANBC_DEFAULT_SLEEP_TIME (TX_TIMER_TICKS_PER_SECOND / 2)
 
-/*
- * thread and pool constants
- */
-#define CANBC_THREAD_NAME       "CAN Broadcast Thread"
-#define CANBC_THREAD_STACK_SIZE 1024 // TODO: this needs to be profiled
-#define CANBC_CHANNEL_POOL_NAME "CAN Broadcast Channel Pool"
-#define CANBC_SEGMENT_POOL_NAME "CAN Broadcast Segment Pool"
-#define CANBC_TICK_TIMER_NAME   "CAN Broadcast Tick Timer"
+// temporary definitions until messages added to DBC
+#define CANBC_DRIVER_INPUTS_ID 0x100
 
 /*
- * internal functions
+ * function prototypes
  */
-static canbc_status_t create_status(canbc_handle_t* canbc_h);
-
-static void create_message(canbc_segment_t* segment_ptr, rtcan_msg_t* msg_ptr);
-
-static bool no_errors(canbc_handle_t* canbc_h);
-
-static void canbc_tick_callback(ULONG input);
 
 static void canbc_thread_entry(ULONG input);
+static void sleep_till_next_bc(canbc_handle_t* canbc_h, uint32_t start_time);
+static void send_bc_messages(canbc_handle_t* canbc_h);
 
 /**
- * @brief       Initialises the CAN broadcast service
+ * @brief       Initialise CANBC service
  *
- * @param[in]   canbc_h             CAN broadcast handle
- * @param[in]   rtcan_h             RTCAN service handle for broadcasting data
- * @param[in]   priority            Service thread priority
- * @param[in]   broadcast_period    Broadcast period in milliseconds
- * @param[in]   stack_pool_ptr      Memory pool to allocate stack memory from
+ * @param[in]   canbc_h         CANBC handle
+ * @param[in]   rtcan_h         RTCAN handle
+ * @param[in]   period          Broadcast period in ticks
+ * @param[in]   priority        CANBC service thread priority
+ * @param[in]   stack_pool_ptr  Application memory pool
  */
-canbc_status_t canbc_init(canbc_handle_t* canbc_h,
-                          rtcan_handle_t* rtcan_h,
-                          UINT priority,
-                          uint32_t broadcast_period,
-                          TX_BYTE_POOL* stack_pool_ptr)
+void canbc_init(canbc_handle_t* canbc_h,
+                rtcan_handle_t* rtcan_h,
+                uint32_t period,
+                uint32_t priority,
+                TX_BYTE_POOL* stack_pool_ptr)
 {
     canbc_h->rtcan_h = rtcan_h;
-    canbc_h->first_segment_ptr = NULL;
+    canbc_h->bc_period = period;
 
-    // timer tick period in ticks
-    canbc_h->tick_period
-        = (broadcast_period * TX_TIMER_TICKS_PER_SECOND) / 1000;
-
-    if (canbc_h->tick_period == 0)
-    {
-        canbc_h->err |= CANBC_ERROR_ARG; // too fast!
-    }
-
-    // memory pool for channels
-    UINT tx_status;
-
-    if (no_errors(canbc_h))
-    {
-        tx_status = tx_block_pool_create(&canbc_h->channel_pool,
-                                         CANBC_CHANNEL_POOL_NAME,
-                                         CANBC_CHANNEL_POOL_BLOCK_SIZE,
-                                         canbc_h->channel_pool_mem,
-                                         CANBC_CHANNEL_POOL_SIZE);
-        if (tx_status != TX_SUCCESS)
-        {
-            canbc_h->err |= CANBC_ERROR_INIT;
-        }
-    }
-
-    // memory pool for segments
-    if (no_errors(canbc_h))
-    {
-        tx_status = tx_block_pool_create(&canbc_h->segment_pool,
-                                         CANBC_SEGMENT_POOL_NAME,
-                                         CANBC_SEGMENT_POOL_BLOCK_SIZE,
-                                         canbc_h->segment_pool_mem,
-                                         CANBC_SEGMENT_POOL_SIZE);
-
-        if (tx_status != TX_SUCCESS)
-        {
-            canbc_h->err |= CANBC_ERROR_INIT;
-        }
-    }
-
-    // service thread
+    // create service thread
     void* stack_ptr = NULL;
+    UINT tx_status = tx_byte_allocate(stack_pool_ptr,
+                                      &stack_ptr,
+                                      CANBC_THREAD_STACK_SIZE,
+                                      TX_NO_WAIT);
 
-    if (no_errors(canbc_h))
-    {
-        tx_status = tx_byte_allocate(stack_pool_ptr,
-                                     &stack_ptr,
-                                     CANBC_THREAD_STACK_SIZE,
-                                     TX_NO_WAIT);
-
-        if (tx_status != TX_SUCCESS)
-        {
-            canbc_h->err |= CANBC_ERROR_INIT;
-        }
-    }
-
-    if (no_errors(canbc_h))
+    if (tx_status == TX_SUCCESS)
     {
         tx_status = tx_thread_create(&canbc_h->thread,
                                      CANBC_THREAD_NAME,
@@ -118,220 +61,28 @@ canbc_status_t canbc_init(canbc_handle_t* canbc_h,
                                      priority,
                                      TX_NO_TIME_SLICE,
                                      TX_DONT_START);
-
-        if (tx_status != TX_SUCCESS)
-        {
-            canbc_h->err |= CANBC_ERROR_INIT;
-        }
     }
 
-    // tick timer
-    if (no_errors(canbc_h))
-    {
-        tx_status = tx_timer_create(&canbc_h->tick_timer,
-                                    CANBC_TICK_TIMER_NAME,
-                                    canbc_tick_callback,
-                                    (ULONG) canbc_h,
-                                    canbc_h->tick_period,
-                                    canbc_h->tick_period,
-                                    TX_NO_ACTIVATE);
-
-        if (tx_status != TX_SUCCESS)
-        {
-            canbc_h->err |= CANBC_ERROR_INIT;
-        }
-    }
-
-    return create_status(canbc_h);
-}
-
-/**
- * @brief       Starts the CAN broadcast service
- *
- * @param[in]   canbc_h     CAN broadcast handle
- */
-canbc_status_t canbc_start(canbc_handle_t* canbc_h)
-{
-    if (no_errors(canbc_h))
-    {
-        UINT tx_status = tx_thread_resume(&canbc_h->thread);
-
-        if (tx_status != TX_SUCCESS)
-        {
-            canbc_h->err |= CANBC_ERROR_INIT;
-        }
-    }
-
-    if (no_errors(canbc_h))
-    {
-        UINT tx_status = tx_timer_activate(&canbc_h->tick_timer);
-
-        if (tx_status != TX_SUCCESS)
-        {
-            canbc_h->err |= CANBC_ERROR_INIT;
-        }
-    }
-
-    return create_status(canbc_h);
-}
-
-/**
- * @brief       Creates a new segment
- *
- * @param[in]   canbc_h     CAN broadcast handle
- * @param[out]  segment_ptr     Pointer to store address of created segment
- * @param[in]   identifier      Identifier for new segment
- * @param[in]   mutex_ptr       Mutex protecting access to segment
- */
-canbc_status_t canbc_create_segment(canbc_handle_t* canbc_h,
-                                    canbc_segment_t** segment_ptr,
-                                    uint32_t identifier,
-                                    TX_MUTEX* mutex_ptr)
-{
-    canbc_segment_t* new_segment;
-
-    UINT tx_status = tx_block_allocate(&canbc_h->segment_pool,
-                                       (void**) &new_segment,
-                                       TX_NO_WAIT);
-
+    // create state mutex
     if (tx_status == TX_SUCCESS)
     {
-        // add the new segment to the linked list
-        if (canbc_h->first_segment_ptr == NULL)
-        {
-            canbc_h->first_segment_ptr = new_segment;
-        }
-        else
-        {
-            canbc_segment_t* end_segment_ptr = canbc_h->first_segment_ptr;
-
-            while (end_segment_ptr != NULL)
-            {
-                end_segment_ptr = end_segment_ptr->next_segment_ptr;
-            }
-        }
-
-        // write config into segment
-        new_segment->identifier = identifier;
-        new_segment->mutex_ptr = mutex_ptr;
-        new_segment->first_channel_ptr = NULL;
-        new_segment->bytes_used = 0;
-        new_segment->next_segment_ptr = NULL;
-
-        // update address of pointer parameter
-        *segment_ptr = new_segment;
-    }
-    else
-    {
-        canbc_h->err |= CANBC_ERROR_MEMORY_FULL;
-        *segment_ptr = NULL;
+        tx_status
+            = tx_mutex_create(&canbc_h->state_mutex, CANBC_STATE_MUTEX_NAME, 0);
     }
 
-    return create_status(canbc_h);
-}
-
-/**
- * @brief       Creates a new channel and adds it to a segment
- *
- * @param[in]   canbc_h     CAN broadcast handle
- * @param[out]  channel_ptr     Pointer to store address of created channel
- * @param[in]   segment_ptr     Pointer to segment to add channel to
- * @param[in]   data_ptr        Pointer to data which channel logs
- * @param[in]   data_length     Length of data which channel logs in bytes
- */
-canbc_status_t canbc_create_channel(canbc_handle_t* canbc_h,
-                                    canbc_channel_t** channel_ptr,
-                                    canbc_segment_t* segment_ptr,
-                                    uint8_t* data_ptr,
-                                    uint32_t data_length)
-{
-    canbc_channel_t* new_channel;
-
-    UINT tx_status = tx_block_allocate(&canbc_h->channel_pool,
-                                       (void**) &new_channel,
-                                       TX_NO_WAIT);
-
+    // start service
     if (tx_status == TX_SUCCESS)
     {
-        // add the new channel to the linked list in the segment
-        if (segment_ptr->first_channel_ptr == NULL)
-        {
-            segment_ptr->first_channel_ptr = new_channel;
-        }
-        else
-        {
-            canbc_channel_t* last_channel_ptr = segment_ptr->first_channel_ptr;
-
-            while (last_channel_ptr->next_channel_ptr != NULL)
-            {
-                last_channel_ptr = last_channel_ptr->next_channel_ptr;
-            }
-
-            last_channel_ptr->next_channel_ptr = new_channel;
-        }
-
-        // only continue if data length will not exceed maximum
-        if (segment_ptr->bytes_used + data_length > CANBC_BYTES_PER_SEGMENT)
-        {
-            canbc_h->err |= CANBC_ERROR_SEGMENT_FULL;
-        }
-        else
-        {
-            // write config into channel
-            new_channel->data_ptr = data_ptr;
-            new_channel->data_length = data_length;
-            new_channel->next_channel_ptr = NULL;
-            new_channel->byte_offset = segment_ptr->bytes_used;
-
-            segment_ptr->bytes_used += data_length;
-
-            // return new channel
-            *channel_ptr = new_channel;
-        }
+        tx_thread_resume(&canbc_h->thread);
     }
-    else
-    {
-        canbc_h->err |= CANBC_ERROR_MEMORY_FULL;
-        *channel_ptr = NULL;
-    }
-
-    return create_status(canbc_h);
 }
 
 /**
- * @brief       Returns the error code
+ * @brief       CANBC service thread
  *
- * @param[in]   canbc_h     CAN broadcast handle
- */
-uint32_t canbc_get_error(canbc_handle_t* canbc_h)
-{
-    return canbc_h->err;
-}
-/**
- * @brief       Tick timer callback
+ * @details     Wakes periodically to broadcast to the CAN bus
  *
  * @param[in]   input   CANBC handle
- */
-static void canbc_tick_callback(ULONG input)
-{
-    canbc_handle_t* canbc_h = (canbc_handle_t*) input;
-
-    // restart thread
-    if (no_errors(canbc_h))
-    {
-        UINT status = tx_thread_resume(&canbc_h->thread);
-
-        if (status != TX_SUCCESS)
-        {
-            canbc_h->err |= CANBC_ERROR_INTERNAL;
-        }
-    }
-}
-
-/**
- * @brief       Entry function for CAN broadcast service thread
- *
- * @param[in]   input  CAN broadcast handle
  */
 static void canbc_thread_entry(ULONG input)
 {
@@ -339,77 +90,98 @@ static void canbc_thread_entry(ULONG input)
 
     while (1)
     {
-        // send off each channel for transmission
-        canbc_segment_t* segment_ptr = canbc_h->first_segment_ptr;
-
-        while (segment_ptr != NULL)
-        {
-            rtcan_msg_t message;
-            create_message(segment_ptr, &message);
-
-            rtcan_transmit(canbc_h->rtcan_h, &message);
-
-            segment_ptr = segment_ptr->next_segment_ptr;
-        }
-
-        // suspend until resumed by next tick
-        // TODO: handle error
-        (void) tx_thread_suspend(&canbc_h->thread);
+        uint32_t start_time = tx_time_get();
+        send_bc_messages(canbc_h);
+        sleep_till_next_bc(canbc_h, start_time);
     }
 }
 
 /**
- * @brief       Populates the RTCAN message with the combined data from all
- *              channels in a segment
+ * @brief       Sends broadcast messages via RTCAN
  *
- * @param[in]   segment_ptr     Pointer to segment
- * @param[out]  msg_ptr         Pointer to RTCAN message to populate
+ * @param[in]   canbc_h     CANBC handle
  */
-static void create_message(canbc_segment_t* segment_ptr, rtcan_msg_t* msg_ptr)
+static void send_bc_messages(canbc_handle_t* canbc_h)
 {
-    bool needs_lock = (segment_ptr->mutex_ptr != NULL);
+    UINT tx_status = tx_mutex_get(&canbc_h->state_mutex, TX_WAIT_FOREVER);
 
-    msg_ptr->identifier = segment_ptr->identifier;
-    msg_ptr->length = segment_ptr->bytes_used;
-
-    if (needs_lock)
+    if (tx_status == TX_SUCCESS)
     {
-        tx_mutex_get(segment_ptr->mutex_ptr, TX_WAIT_FOREVER);
-    }
+        // driver inputs
+        rtcan_msg_t message
+            = {.identifier = CAN_DATABASE_VCU_DRIVER_INPUTS_FRAME_ID,
+               .length = CAN_DATABASE_VCU_DRIVER_INPUTS_LENGTH};
 
-    canbc_channel_t* channel_ptr = segment_ptr->first_channel_ptr;
+        struct can_database_vcu_driver_inputs_t driver_inputs = {
+            .vcu_apps = canbc_h->states.apps_reading,
+            .vcu_bps = canbc_h->states.bps_reading,
+        };
 
-    while (channel_ptr != NULL)
-    {
-        memcpy(msg_ptr->data + channel_ptr->byte_offset,
-               channel_ptr->data_ptr,
-               channel_ptr->data_length);
+        can_database_vcu_driver_inputs_pack(
+            message.data,
+            &driver_inputs,
+            CAN_DATABASE_VCU_DRIVER_INPUTS_LENGTH);
 
-        channel_ptr = channel_ptr->next_channel_ptr;
-    }
+        rtcan_transmit(canbc_h->rtcan_h, &message);
 
-    if (needs_lock)
-    {
-        tx_mutex_put(segment_ptr->mutex_ptr);
+        // TODO: VCU internal states
+
+        tx_mutex_put(&canbc_h->state_mutex);
     }
 }
 
 /**
- * @brief       Returns true if the broadcaster has encountered an error
+ * @brief       Suspends CANBC thread until the next broadcast is due
  *
- * @param[in]   canbc_h     CAN broadcast handle
+ * @param[in]   canbc_h     CANBC handle
+ * @param[in]   start_time  Timestamp at which last broadcast event started
  */
-static bool no_errors(canbc_handle_t* canbc_h)
+static void sleep_till_next_bc(canbc_handle_t* canbc_h, uint32_t start_time)
 {
-    return (canbc_h->err == CANBC_ERROR_NONE);
+    uint32_t run_time = tx_time_get() - start_time;
+    uint32_t sleep_time = canbc_h->bc_period - run_time;
+
+    // check for overflow or zero, just in case
+    if (run_time >= canbc_h->bc_period)
+    {
+        sleep_time = CANBC_DEFAULT_SLEEP_TIME;
+    }
+
+    tx_thread_sleep(sleep_time);
 }
 
 /**
- * @brief       Create a status code based on the current error state
+ * @brief       Locks the broadcast states for editing
  *
- * @param[in]   canbc_h     CAN broadcast handle
+ * @details     If the CANBC thread or another system service has the lock and
+ *              the timeout is reached, NULL is returned.
+ *
+ *              `canbc_unlock_state()` must be called as soon as possible after
+ *              editing states.
+ *
+ *
+ * @param[in]   canbc_h     CANBC handle
+ * @param[in]   timeout     Timeout in ticks to acquire lock
  */
-static canbc_status_t create_status(canbc_handle_t* canbc_h)
+canbc_states_t* canbc_lock_state(canbc_handle_t* canbc_h, uint32_t timeout)
 {
-    return (no_errors(canbc_h)) ? CANBC_OK : CANBC_ERROR;
+    UINT tx_status = tx_mutex_get(&canbc_h->state_mutex, timeout);
+    canbc_states_t* ret = NULL;
+
+    if (tx_status == TX_SUCCESS)
+    {
+        ret = &canbc_h->states;
+    }
+
+    return ret;
+}
+
+/**
+ * @brief       Releases CANBC states after editing
+ *
+ * @param[in]   canbc_h     CANBC handle
+ */
+void canbc_unlock_state(canbc_handle_t* canbc_h)
+{
+    tx_mutex_put(&canbc_h->state_mutex);
 }

--- a/src/SUFST/Src/CAN/pm100.c
+++ b/src/SUFST/Src/CAN/pm100.c
@@ -85,44 +85,6 @@ status_t pm100_init(pm100_handle_t* pm100_h, rtcan_handle_t* rtcan_h)
 }
 
 /**
- * @brief       Enables the inverter, suspending the calling thread until
- *              the process is complete
- *
- * @details     The inverter initialises in the "lockout" state. To enable it,
- *              a disable command must first be sent.
- *
- * @see         "Cascadia Motion CAN Protocol" v5.9 p.35
- *
- * @param[in]   pm100_h     PM100 handle
- */
-status_t pm100_enable(pm100_handle_t* pm100_h)
-{
-    // // disable inverter
-    // status_t status = pm100_disable(pm100_h);
-
-    // // wait for lockout
-    // if (status == STATUS_OK)
-    // {
-    //     pm100_h->waiting_on_lockout = true;
-
-    //     status = (tx_semaphore_get(&pm100_h->lockout_sem, TX_WAIT_FOREVER)
-    //               == TX_SUCCESS)
-    //                  ? STATUS_OK
-    //                  : STATUS_ERROR;
-
-    //     pm100_h->waiting_on_lockout = false;
-    // }
-
-    // // send a zero torque request
-    // if (status == STATUS_OK)
-    // {
-    //     status = pm100_request_torque(pm100_h, 0);
-    // }
-
-    return STATUS_OK;
-}
-
-/**
  * @brief       Disables the inverter
  *
  * @details     Disable command consists of all zeros in data field.
@@ -145,6 +107,9 @@ status_t pm100_disable(pm100_handle_t* pm100_h)
 
 /**
  * @brief       Sends a torque request to the inverter
+ *
+ * @details     If the inverter is in the lockout state, a disable command will
+ *              be sent instead to get it out of lockout.
  *
  * @see         "Cascadia Motion CAN Protocol" v5.9 p.31
  *

--- a/src/SUFST/Src/Sensors/apps.c
+++ b/src/SUFST/Src/Sensors/apps.c
@@ -6,12 +6,14 @@
 
 #include "apps.h"
 
+#include <adc.h>
 #include <stdbool.h>
 
-#include "adc.h"
 #include "config.h"
 #include "scs.h"
 #include "trace.h"
+
+#define APPS_SCALED_MAX 1000 // maximum scaled value
 
 /**
  * @brief Safety critical signal instances for APPS
@@ -28,21 +30,19 @@ bool apps_inputs_agree(const uint32_t inputs[2]);
  */
 void apps_init()
 {
-    uint32_t apps_signal_max = (1 << APPS_SCALED_RESOLUTION) - 1;
-
     scs_create(&apps_signals[0],
                &hadc1,
                APPS_1_ADC_MIN,
                APPS_1_ADC_MAX,
                0,
-               apps_signal_max);
+               APPS_SCALED_MAX);
 
     scs_create(&apps_signals[1],
                &hadc2,
                APPS_2_ADC_MIN,
                APPS_2_ADC_MAX,
                0,
-               apps_signal_max);
+               APPS_SCALED_MAX);
 }
 
 /**
@@ -97,8 +97,7 @@ bool apps_inputs_agree(const uint32_t inputs[2])
 {
     uint32_t diff = (inputs[1] > inputs[0]) ? inputs[1] - inputs[0]
                                             : inputs[0] - inputs[1];
-    static const uint32_t max_diff
-        = APPS_MAX_DIFF_FRACTION * ((1 << APPS_SCALED_RESOLUTION) - 1);
+    static const uint32_t max_diff = APPS_MAX_DIFF_FRACTION * APPS_SCALED_MAX;
 
     return diff < max_diff;
 }

--- a/src/SUFST/Src/Sensors/scs.c
+++ b/src/SUFST/Src/Sensors/scs.c
@@ -49,8 +49,9 @@ void scs_create(scs_t* scs_ptr,
     uint32_t mapped_range = max - min;
 
     scs_ptr->scale_up = (adc_range < mapped_range);
-    scs_ptr->scale_factor = scs_ptr->scale_up ? mapped_range / adc_range
-                                              : adc_range / mapped_range;
+    scs_ptr->scale_factor = scs_ptr->scale_up
+                                ? ((float) mapped_range / adc_range)
+                                : ((float) adc_range / mapped_range);
     scs_ptr->max_bounds_diff = adc_range * SCS_OUTSIDE_BOUNDS_FRACTION;
 }
 

--- a/src/SUFST/Src/Tasks/driver_control.c
+++ b/src/SUFST/Src/Tasks/driver_control.c
@@ -169,6 +169,7 @@ static void driver_ctrl_thread_entry(ULONG input)
                 != TS_CTRL_OK)
             {
                 // TODO: handle error?
+                Error_Handler();
             }
 
             // update states all at the same time

--- a/src/SUFST/Src/Tasks/ts_control.c
+++ b/src/SUFST/Src/Tasks/ts_control.c
@@ -189,6 +189,9 @@ static void ts_ctrl_thread_entry(ULONG input)
     }
 
     // loop forever
+    // const uint32_t heartbeat_timeout = 5 * TX_TIMER_TICKS_PER_SECOND /
+    // (DRIVER_CTRL_TICK_RATE);
+
     while (1)
     {
         // wait for a message to enter the control input queue
@@ -219,6 +222,11 @@ static void ts_ctrl_thread_entry(ULONG input)
                 Error_Handler();
             }
         }
+        // else
+        // {
+        //     pm100_disable(&ts_ctrl_h->pm100);
+        //     pm100_process_broadcast_msgs(&ts_ctrl_h->pm100);
+        // }
     }
 }
 

--- a/src/SUFST/Src/vcu.c
+++ b/src/SUFST/Src/vcu.c
@@ -71,21 +71,11 @@ vcu_status_t vcu_init(vcu_handle_t* vcu_h,
     // CAN broadcast service
     if (no_errors(vcu_h))
     {
-        canbc_status_t status = canbc_init(&vcu_h->canbc,
-                                           &vcu_h->rtcan_s,
-                                           CANBC_PRIORITY,
-                                           CANBC_BROADCAST_PERIOD,
-                                           app_mem_pool);
-
-        if (status == CANBC_OK)
-        {
-            status = canbc_start(&vcu_h->canbc);
-        }
-
-        if (status != CANBC_OK)
-        {
-            vcu_h->err |= VCU_ERROR_INIT;
-        }
+        canbc_init(&vcu_h->canbc,
+                   &vcu_h->rtcan_c,
+                   CANBC_BROADCAST_PERIOD,
+                   CANBC_PRIORITY,
+                   app_mem_pool);
     }
 
     // initialisation thread
@@ -284,8 +274,10 @@ static void init_thread_entry(ULONG input)
     rtd_wait(&vcu_h->rtd);
 
     // TODO: handle errors
-    (void) ts_ctrl_start(&vcu_h->ts_ctrl);
     (void) driver_ctrl_start(&vcu_h->driver_ctrl);
+    (void) ts_ctrl_start(
+        &vcu_h
+             ->ts_ctrl); // start this immediately to avoid inverter CAN timeout
 
     (void) tx_thread_terminate(&vcu_h->init_thread);
 }


### PR DESCRIPTION
### Changes

- Simplified existing system which was slightly over-engineered and hard to use.
- Added broadcasting of R2D state, rolling counter, APPS and BPS readings.

### Fixed Issue(s)

Closes #161 
Closes #174 
Closes #176 

### Checklist

- [x] Code has been tested on STM32 hardware.
- [x] Changes do not generate any new compiler warnings.
- [x] Code has been formatted using `trunk fmt`.
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.

### Additional Notes

Tested with L120 datalogger with latest DBC from `can-defs` repo.
