### PR TITLE
chore: update launch configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,27 +10,7 @@
       "showDevDebugOutput": "none",
       "servertype": "stutil",
       "svdFile": "debug/STM32F7x6.svd",
-      "osx": {
-        "name": "debug (stutil)",
-        "executable": "build/VCU.elf",
-        "request": "launch",
-        "type": "cortex-debug",
-        "serverpath": "st-util"
-      },
-      "linux": {
-        "name": "debug (stutil)",
-        "executable": "build/VCU.elf",
-        "request": "launch",
-        "type": "cortex-debug",
-        "serverpath": "st-util"
-      },
-      "windows": {
-        "name": "debug (stutil)",
-        "executable": "build/VCU.elf",
-        "request": "launch",
-        "type": "cortex-debug",
-        "serverpath": "st-util"
-      }
+      "serverpath": "st-util"
     },
     // debug with openocd
     {
@@ -42,12 +22,7 @@
       "showDevDebugOutput": "none",
       "servertype": "openocd",
       "configFiles": ["interface/stlink.cfg", "target/stm32f7x.cfg"],
-      "osx": {
-        "serverpath": "openocd"
-      },
-      "linux": {
-        "serverpath": "openocd"
-      }
+      "serverpath": "openocd"
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,6 @@
         "executable": "build/VCU.elf",
         "request": "launch",
         "type": "cortex-debug",
-        "armToolchainPath": "/Applications/ARM/bin",
         "serverpath": "st-util"
       },
       "linux": {
@@ -23,15 +22,13 @@
         "executable": "build/VCU.elf",
         "request": "launch",
         "type": "cortex-debug",
-        "armToolchainPath": "?",
-        "serverpath": "?"
+        "serverpath": "st-util"
       },
       "windows": {
         "name": "debug (stutil)",
         "executable": "build/VCU.elf",
         "request": "launch",
         "type": "cortex-debug",
-        "armToolchainPath": "C:\\Program Files (x86)\\GNU Arm Embedded Toolchain\\10 2021.10\\bin",
         "serverpath": "st-util"
       }
     },
@@ -44,14 +41,12 @@
       "type": "cortex-debug",
       "showDevDebugOutput": "none",
       "servertype": "openocd",
-      "configFiles": ["interface/stlink.cfg", "target/stm32h7x.cfg"],
+      "configFiles": ["interface/stlink.cfg", "target/stm32f7x.cfg"],
       "osx": {
-        "armToolchainPath": "/Applications/ARM/bin",
         "serverpath": "openocd"
       },
       "linux": {
-        "armToolchainPath": "?",
-        "serverpath": "?"
+        "serverpath": "openocd"
       }
     }
   ]


### PR DESCRIPTION
### Changes

Updated the VS Code launch configurations to delegate specifying where the ARM GNU toolchain is to the user settings (as it varies).

Also changed the OpenOCD target from the H7 to the F7 series as the H7 is NLA and we use F746ZG anyway.

### Fixed Issue(s)

NA

### Checklist

- [x] Code has been tested on STM32 hardware.
- [x] Changes do not generate any new compiler warnings.
- [x] Code has been formatted using `trunk fmt`.
- [x] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.

