### PR TITLE
build: use ${MAKE} instead of make in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ vpath %.s $(sort $(dir $(ASM_SOURCES)))
 
 # default build all
 all: 
-	make $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin \
+	${MAKE} $(BUILD_DIR)/$(TARGET).elf $(BUILD_DIR)/$(TARGET).hex $(BUILD_DIR)/$(TARGET).bin \
 
 # pre build
 .PHONY: prebuild


### PR DESCRIPTION
### Changes

Changes the `Makefile` to use `${MAKE}` when invoking itself instead of `make`. This allows arguments like `--dry-run` to be inherited, and external tooling like `ccdgen` to work correctly.
