### PR TITLE
add a check if bps is zero and abort r2d

### DIFF
--- a/src/SUFST/Inc/Interfaces/bps.h
+++ b/src/SUFST/Inc/Interfaces/bps.h
@@ -30,6 +30,6 @@ typedef struct
 status_t bps_init(bps_context_t* bps_ptr, const config_bps_t* config_ptr);
 status_t bps_read(bps_context_t* bps_ptr, uint16_t* reading_ptr);
 bool bps_fully_pressed(bps_context_t* bps_ptr);
-bool bps_zero(bps_context_t* bps_ptr);
+bool bps_valid(bps_context_t* bps_ptr);
 
 #endif

--- a/src/SUFST/Inc/Interfaces/bps.h
+++ b/src/SUFST/Inc/Interfaces/bps.h
@@ -30,5 +30,6 @@ typedef struct
 status_t bps_init(bps_context_t* bps_ptr, const config_bps_t* config_ptr);
 status_t bps_read(bps_context_t* bps_ptr, uint16_t* reading_ptr);
 bool bps_fully_pressed(bps_context_t* bps_ptr);
+bool bps_zero(bps_context_t* bps_ptr);
 
 #endif

--- a/src/SUFST/Src/Interfaces/bps.c
+++ b/src/SUFST/Src/Interfaces/bps.c
@@ -53,3 +53,23 @@ bool bps_fully_pressed(bps_context_t* bps_ptr)
 
     return (status == STATUS_OK) && above_threshold;
 }
+
+/**
+ * @brief
+ *
+ * @param[in]   bps_ptr     BPS context
+ *
+ * @retval  true    BPS not pressed, or SCS fault
+ * @retval  false   BPS is pressed
+ */
+bool bps_zero(bps_context_t* bps_ptr)  
+{
+    uint16_t reading = 0;
+    status_t status = bps_read(bps_ptr, &reading);
+    if (status == STATUS_OK){
+        if (reading != 0){
+            return false;
+        }
+    }
+    return true ;
+}

--- a/src/SUFST/Src/Interfaces/bps.c
+++ b/src/SUFST/Src/Interfaces/bps.c
@@ -59,17 +59,18 @@ bool bps_fully_pressed(bps_context_t* bps_ptr)
  *
  * @param[in]   bps_ptr     BPS context
  *
- * @retval  true    BPS not pressed, or SCS fault
- * @retval  false   BPS is pressed
+ * @retval  true    BPS is pressed
+ * @retval  false   BPS is not pressed, or SCS fault
  */
-bool bps_zero(bps_context_t* bps_ptr)  
+bool bps_valid(bps_context_t* bps_ptr)  
 {
     uint16_t reading = 0;
     status_t status = bps_read(bps_ptr, &reading);
-    if (status == STATUS_OK){
-        if (reading != 0){
-            return false;
-        }
-    }
-    return true ;
+    // if (status == STATUS_OK){
+    //     if (reading != 0){
+    //         return false;
+    //     }
+    // }
+    // return true ;
+    return (status == STATUS_OK) && (reading != 0);
 }

--- a/src/SUFST/Src/Services/ctrl.c
+++ b/src/SUFST/Src/Services/ctrl.c
@@ -244,6 +244,11 @@ void ctrl_state_machine_tick(ctrl_context_t* ctrl_ptr)
 
         if (r2d)
         {
+            if (bps_zero(&ctrl_ptr->bps)){
+                next_state = CTRL_STATE_TS_ACTIVATION_FAILURE;
+                LOG_ERROR(log_h, "BPS is zero\n");
+                break;
+            }
             dash_set_r2d_led_state(dash_ptr, GPIO_PIN_SET);
             rtds_activate(ctrl_ptr->rtds_config_ptr);
 
@@ -265,6 +270,12 @@ void ctrl_state_machine_tick(ctrl_context_t* ctrl_ptr)
         // read from the APPS
         status_t apps_status
             = apps_read(&ctrl_ptr->apps, &ctrl_ptr->apps_reading);
+        // check brake is not zero
+        if (bps_zero(&ctrl_ptr->bps)){
+                next_state = CTRL_STATE_TS_ACTIVATION_FAILURE;
+                LOG_ERROR(log_h, "BPS is zero\n");
+                break;
+            }
 
         if (apps_status == STATUS_OK)
         {
@@ -294,6 +305,10 @@ void ctrl_state_machine_tick(ctrl_context_t* ctrl_ptr)
 
     // activation or runtime failure
     case (CTRL_STATE_TS_ACTIVATION_FAILURE):
+    {
+        ctrl_handle_ts_fault(ctrl_ptr); // should be the same implementation
+        break;
+    }
     case (CTRL_STATE_TS_RUN_FAULT):
     {
         ctrl_handle_ts_fault(ctrl_ptr);

--- a/src/SUFST/Src/Services/ctrl.c
+++ b/src/SUFST/Src/Services/ctrl.c
@@ -244,7 +244,7 @@ void ctrl_state_machine_tick(ctrl_context_t* ctrl_ptr)
 
         if (r2d)
         {
-            if (bps_zero(&ctrl_ptr->bps)){
+            if (!bps_valid(&ctrl_ptr->bps)){
                 next_state = CTRL_STATE_TS_ACTIVATION_FAILURE;
                 LOG_ERROR(log_h, "BPS is zero\n");
                 break;
@@ -271,7 +271,7 @@ void ctrl_state_machine_tick(ctrl_context_t* ctrl_ptr)
         status_t apps_status
             = apps_read(&ctrl_ptr->apps, &ctrl_ptr->apps_reading);
         // check brake is not zero
-        if (bps_zero(&ctrl_ptr->bps)){
+        if (!bps_valid(&ctrl_ptr->bps)){
                 next_state = CTRL_STATE_TS_ACTIVATION_FAILURE;
                 LOG_ERROR(log_h, "BPS is zero\n");
                 break;
@@ -305,10 +305,6 @@ void ctrl_state_machine_tick(ctrl_context_t* ctrl_ptr)
 
     // activation or runtime failure
     case (CTRL_STATE_TS_ACTIVATION_FAILURE):
-    {
-        ctrl_handle_ts_fault(ctrl_ptr); // should be the same implementation
-        break;
-    }
     case (CTRL_STATE_TS_RUN_FAULT):
     {
         ctrl_handle_ts_fault(ctrl_ptr);


### PR DESCRIPTION
### Changes

- Add bps_zero
- Abort R2D and TS state if BPS=0

### Fixed Issue(s)

Closes 229 (issue)

### Checklist

- [ ] Code has been tested on STM32 hardware.
- [ ] Changes do not generate any new compiler warnings.
- [ ] Code has been formatted using `trunk fmt`.
- [ ] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.

### Additional Notes

Any additional notes.
