### PR TITLE
Feat/r2d pump lockout

### DIFF
--- a/src/SUFST/Inc/Services/pm100.h
+++ b/src/SUFST/Inc/Services/pm100.h
@@ -13,6 +13,7 @@
 #define PM100_H
 
 #include <can_c.h>
+#include <can_s.h>
 #include <rtcan.h>
 #include <stdint.h>
 #include <tx_api.h>

--- a/src/SUFST/Inc/Services/pm100.h
+++ b/src/SUFST/Inc/Services/pm100.h
@@ -49,6 +49,7 @@ typedef struct
     struct can_c_pm100_temperature_set_1_t temp1;
     struct can_c_pm100_temperature_set_2_t temp2;
     struct can_c_pm100_temperature_set_3_t temp3;
+    struct can_s_vcu_pdm_voltage_out vout;
     uint16_t error;
     const config_pm100_t* config_ptr;
 } pm100_context_t;

--- a/src/SUFST/Inc/Services/pm100.h
+++ b/src/SUFST/Inc/Services/pm100.h
@@ -32,6 +32,8 @@
 
 #define PM100_RX_QUEUE_SIZE           10 // 10 items
 
+#define PUMP_RUNNING_THRESHOLD        12 // Voltage/V
+
 /**
  * @brief   PM100 context
  */
@@ -69,5 +71,7 @@ int16_t pm100_motor_temp(pm100_context_t* pm100_ptr);
 int16_t pm100_max_inverter_temp(pm100_context_t* pm100_ptr);
 status_t pm100_disable(pm100_context_t* pm100_ptr);
 status_t pm100_request_torque(pm100_context_t* pm100_ptr, uint16_t torque);
+
+bool pm100_check_pumps_running(pm100_context_t* pm100_ptr);
 
 #endif

--- a/src/SUFST/Inc/Services/pm100.h
+++ b/src/SUFST/Inc/Services/pm100.h
@@ -33,7 +33,7 @@
 
 #define PM100_RX_QUEUE_SIZE           10 // 10 items
 
-#define PUMP_RUNNING_THRESHOLD        12 // Voltage/V
+#define PUMP_RUNNING_THRESHOLD        8 // Voltage/V
 
 /**
  * @brief   PM100 context

--- a/src/SUFST/Inc/config.h
+++ b/src/SUFST/Inc/config.h
@@ -46,6 +46,7 @@ typedef struct {
      config_thread_t thread;                 // control thread config
      uint32_t schedule_ticks;                // number of ticks between runs of the control loop thread
      bool r2d_requires_brake;                // whether or not the brake needs to be pressed for R2D activation
+     bool r2d_requires_pump;                 // whether or not the pump needs to be running for R2D activation
      uint32_t ts_ready_timeout_ticks;        // ticks after which waiting for TS ready times out
      uint32_t ts_ready_poll_ticks;           // how often to poll input when waiting for TS ready
      uint32_t precharge_timeout_ticks;       // ticks after which waiting for precharge times out

--- a/src/SUFST/Src/Services/ctrl.c
+++ b/src/SUFST/Src/Services/ctrl.c
@@ -296,6 +296,10 @@ void ctrl_state_machine_tick(ctrl_context_t* ctrl_ptr)
                           ? (ctrl_ptr->bps_reading > BPS_ON_THRESH)
                           : 1;
 
+                r2d &= (config_ptr->r2d_requires_pump)
+                           ? pm100_check_pumps_running(ctrl_ptr->pm100_ptr)
+                           : 1;
+
                 if (r2d)
                 {
                     dash_set_r2d_led_state(dash_ptr, GPIO_PIN_SET);

--- a/src/SUFST/Src/Services/ctrl.c
+++ b/src/SUFST/Src/Services/ctrl.c
@@ -242,12 +242,14 @@ void ctrl_state_machine_tick(ctrl_context_t* ctrl_ptr)
 
     // TS is ready, can initiate pre-charge sequence
     // TS on LED turns solid
+    // powers on pumps in preparation for r2d
     case (CTRL_STATE_PRECHARGE_WAIT):
     {
         const uint32_t charge_time = tx_time_get() - ctrl_ptr->precharge_start;
 
         if (pm100_is_precharged(ctrl_ptr->pm100_ptr))
         {
+            ctrl_ptr->pump_pwr = 1;
             next_state = CTRL_STATE_R2D_WAIT;
             dash_clear_buttons(dash_ptr);
             LOG_INFO("Precharge complete\n");
@@ -305,7 +307,6 @@ void ctrl_state_machine_tick(ctrl_context_t* ctrl_ptr)
                     dash_set_r2d_led_state(dash_ptr, GPIO_PIN_SET);
                     pm100_disable(ctrl_ptr->pm100_ptr);
                     rtds_activate(ctrl_ptr->rtds_config_ptr);
-                    ctrl_ptr->pump_pwr = 1;
 
                     next_state = CTRL_STATE_TS_ON;
 

--- a/src/SUFST/Src/Services/ctrl.c
+++ b/src/SUFST/Src/Services/ctrl.c
@@ -264,6 +264,7 @@ void ctrl_state_machine_tick(ctrl_context_t* ctrl_ptr)
 
     // pre-charge is complete, wait for R2D signal
     // also wait for brake to be fully pressed (if enabled)
+    // also wait for pumps to be running (if enabled)
     case (CTRL_STATE_R2D_WAIT):
     {
         if (!trc_ready())

--- a/src/SUFST/Src/Services/pm100.c
+++ b/src/SUFST/Src/Services/pm100.c
@@ -447,6 +447,7 @@ status_t pm100_request_torque(pm100_context_t* pm100_ptr, uint16_t torque)
 
 bool pm100_check_pumps_running(pm100_context_t* pm100_ptr)
 {
-    return (pm100_ptr->vout->pdm_output_4_voltage > PUMP_RUNNING_THRESHOLD)
-           && (pm100_ptr->vout->pdm_output_5_voltage > PUMP_RUNNING_THRESHOLD);
+    return (&(&pm100_ptr->vout)->pdm_output_4_voltage > PUMP_RUNNING_THRESHOLD)
+           && (&(&pm100_ptr->vout)->pdm_output_5_voltage
+               > PUMP_RUNNING_THRESHOLD);
 }

--- a/src/SUFST/Src/Services/pm100.c
+++ b/src/SUFST/Src/Services/pm100.c
@@ -132,7 +132,8 @@ void pm100_thread_entry(ULONG input)
                                 CAN_C_PM100_FAULT_CODES_FRAME_ID,
                                 CAN_C_PM100_TEMPERATURE_SET_1_FRAME_ID,
                                 CAN_C_PM100_TEMPERATURE_SET_2_FRAME_ID,
-                                CAN_C_PM100_TEMPERATURE_SET_3_FRAME_ID};
+                                CAN_C_PM100_TEMPERATURE_SET_3_FRAME_ID,
+                                CAN_S_VCU_PDM_OUT_VOLTAGE_FRAME_ID};
 
     for (uint32_t i = 0; i < sizeof(subscriptions) / sizeof(subscriptions[0]);
          i++)
@@ -240,6 +241,15 @@ void process_broadcast(pm100_context_t* pm100_ptr, const rtcan_msg_t* msg_ptr)
         can_c_pm100_temperature_set_3_unpack(&pm100_ptr->temp3,
                                              msg_ptr->data,
                                              msg_ptr->length);
+
+        break;
+    }
+
+    case CAN_S_VCU_PDM_OUT_VOLTAGE_FRAME_ID:
+    {
+        can_s_vcu_pdm_voltage_out_unpack(&pm100_ptr->vout,
+                                         msg_ptr->data,
+                                         msg_ptr->length);
 
         break;
     }

--- a/src/SUFST/Src/Services/pm100.c
+++ b/src/SUFST/Src/Services/pm100.c
@@ -444,3 +444,9 @@ status_t pm100_request_torque(pm100_context_t* pm100_ptr, uint16_t torque)
 
     return status;
 }
+
+bool pm100_check_pumps_running(pm100_context_t* pm100_ptr)
+{
+    return (pm100_ptr->vout->pdm_output_4_voltage > PUMP_RUNNING_THRESHOLD)
+           && (pm100_ptr->vout->pdm_output_5_voltage > PUMP_RUNNING_THRESHOLD);
+}

--- a/src/SUFST/Src/config.c
+++ b/src/SUFST/Src/config.c
@@ -91,6 +91,7 @@ static const config_t config_instance = {
         },
         .schedule_ticks = SECONDS_TO_TICKS(0.01), // 100Hz control loop
         .r2d_requires_brake = true,
+        .r2d_requires_pump = true,
         .bps_on_threshold = 5,
 	    .apps_bps_low_threshold = 5,
 	    .apps_bps_high_threshold = 20,


### PR DESCRIPTION
### Changes

- Subscribe to PDM_Output_Voltage
- Check pumps running (PDM_Output_Voltage) before entering R2D

### Fixed Issue(s)

Closes [#238](https://github.com/sufst/vcu/issues/238) 

### Checklist

- [ ] Code has been tested on STM32 hardware.
- [X] Changes do not generate any new compiler warnings.
- [X] Code has been formatted using `trunk fmt`.
- [X] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification.